### PR TITLE
Add better serde support as well as defualt, clone and debug derive flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,19 +22,16 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = ["full"]
 full = ["fixed-hash/std", "fixed-hash/rand"]
+serde_support = ["serde", "serde-big-array"]
 
 [dependencies]
 hex = "0.4"
 byteorder = "1"
 keccak-hash = "0.3"
 base58-monero = "0.1"
-
-[dependencies.curve25519-dalek]
-version = "1"
-
-[dependencies.serde]
-version = "1"
-optional = true
+serde = { version = "1", features = ["derive"], optional = true }
+serde-big-array = {version ="0.2.0", optional = true}
+curve25519-dalek= {version ="1", features = ["serde"]}
 
 [dependencies.fixed-hash]
 version = "0.3"

--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -21,8 +21,12 @@
 use crate::blockdata::transaction::Transaction;
 use crate::consensus::encode::VarInt;
 use crate::cryptonote::hash;
+#[cfg(feature = "serde_support")]
+use serde::{Deserialize, Serialize};
 
 /// Monero block header
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct BlockHeader {
     /// Major version, defines the consensus rules
     pub major_version: VarInt,
@@ -46,6 +50,8 @@ impl_consensus_encoding!(
 );
 
 /// Monero block with all transaction hashes
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct Block {
     /// The block header
     pub header: BlockHeader,

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -28,6 +28,9 @@ use crate::cryptonote::{hash, onetime_key};
 use crate::util::key::{PublicKey, ViewPair};
 use crate::util::ringct::{RctSig, RctSigBase, RctSigPrunable, RctType, Signature};
 
+#[cfg(feature = "serde_support")]
+use serde::{Deserialize, Serialize};
+
 /// Transaction error
 #[derive(Debug)]
 pub enum Error {
@@ -38,7 +41,8 @@ pub enum Error {
 }
 
 /// Input key image
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct KeyImage {
     /// The actual key image
     pub image: hash::Hash,
@@ -48,7 +52,8 @@ impl_consensus_encoding!(KeyImage, image);
 
 /// A transaction input, which defines the ring size and the key image to avoid
 /// double spend.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub enum TxIn {
     /// A coinbase input
     Gen {
@@ -71,7 +76,8 @@ pub enum TxIn {
 }
 
 /// Output format, only output to key is used
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub enum TxOutTarget {
     /// Output to script
     ToScript {
@@ -93,7 +99,8 @@ pub enum TxOutTarget {
 }
 
 /// A transaction output, can be consumed by an input
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct TxOut {
     /// The amount sent to the associated key, can be 0 in case of CT
     pub amount: VarInt,
@@ -117,7 +124,8 @@ pub struct OwnedTxOut<'a> {
 /// Every transaction contains an Extra field, which is a part of transaction prefix
 ///
 /// Extra field is composed of typed sub fields of variable or fixed lenght.
-#[derive(Debug)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct ExtraField(pub Vec<SubField>);
 
 impl ExtraField {
@@ -140,7 +148,8 @@ impl ExtraField {
 
 /// Each sub-field contains a sub-field tag followed by sub-field content of fixed or variable
 /// lenght, in variable lenght case the lenght is encoded with a VarInt before the content itself.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub enum SubField {
     /// Transaction public key, fixed lenght of 32 bytes
     TxPublicKey(PublicKey),
@@ -160,7 +169,8 @@ pub enum SubField {
 /// The part of a transaction that contains all the data except signatures.
 ///
 /// Can generate the transaction prefix hash with `tx_prefix.hash()`
-#[derive(Debug)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct TransactionPrefix {
     /// Transaction format version
     pub version: VarInt,
@@ -261,7 +271,8 @@ impl hash::Hashable for TransactionPrefix {
 }
 
 /// A full transaction containing the prefix and all signing data
-#[derive(Debug)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct Transaction {
     /// The transaction prefix
     pub prefix: TransactionPrefix,

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -35,6 +35,9 @@ use std::u32;
 use crate::blockdata::transaction;
 use crate::util::{key, ringct};
 
+#[cfg(feature = "serde_support")]
+use serde::{Deserialize, Serialize};
+
 /// Encoding error
 #[derive(Debug)]
 pub enum Error {
@@ -246,7 +249,8 @@ pub trait Decodable<D: Decoder>: Sized {
 }
 
 /// A variable-length unsigned integer
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Default)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct VarInt(pub u64);
 
 impl fmt::Display for VarInt {

--- a/src/cryptonote/hash.rs
+++ b/src/cryptonote/hash.rs
@@ -23,9 +23,12 @@ use keccak_hash::keccak_256;
 
 use crate::consensus::encode::{self, Decodable, Decoder, Encodable, Encoder};
 use crate::util::key::PrivateKey;
+#[cfg(feature = "serde_support")]
+use serde::{Deserialize, Serialize};
 
 fixed_hash::construct_fixed_hash!(
     /// Result of a Keccak-256
+    #[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
     pub struct Hash(32);
 );
 
@@ -87,6 +90,7 @@ pub trait Hashable {
 
 fixed_hash::construct_fixed_hash!(
     /// 8 bytes hash
+    #[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
     pub struct Hash8(8);
 );
 

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -314,7 +314,7 @@ impl FromStr for Address {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(any(feature = "serde", feature = "serde_support"))]
 mod serde_impl {
     use super::*;
 

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -74,6 +74,9 @@ use curve25519_dalek::scalar::Scalar;
 use crate::consensus::encode::{self, Decodable, Decoder, Encodable, Encoder};
 use crate::cryptonote::hash;
 
+#[cfg(feature = "serde_support")]
+use serde::{Deserialize, Serialize};
+
 /// An error that might occur during key decoding
 #[derive(Debug, PartialEq)]
 pub enum Error {
@@ -257,6 +260,7 @@ impl<S: Encoder> Encodable<S> for PrivateKey {
 
 /// Monero public key
 #[derive(PartialEq, Eq, Copy, Clone)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct PublicKey {
     /// The actual Ed25519 point
     pub point: CompressedEdwardsY,

--- a/src/util/ringct.rs
+++ b/src/util/ringct.rs
@@ -22,6 +22,18 @@ use std::fmt;
 
 use crate::consensus::encode::{self, serialize, Decodable, Decoder, Encodable, Encoder, VarInt};
 use crate::cryptonote::hash;
+#[cfg(feature = "serde_support")]
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde_support")]
+use serde_big_array_unchecked_docs::*;
+
+///Serde support for array's bigger than 32
+#[allow(missing_docs)]
+#[cfg(feature = "serde_support")]
+pub mod serde_big_array_unchecked_docs {
+    use serde_big_array::big_array;
+    big_array! { BigArray; }
+}
 
 /// RingCT error
 #[derive(Debug)]
@@ -32,6 +44,8 @@ pub enum Error {
 
 // ====================================================================
 /// Raw 32 bytes key
+#[derive(Clone)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct Key {
     /// The actual key
     pub key: [u8; 32],
@@ -43,8 +57,11 @@ impl_consensus_encoding!(Key, key);
 
 // ====================================================================
 /// Raw 64 bytes key
+#[derive(Clone)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct Key64 {
     /// The actual key
+    #[cfg_attr(feature = "serde_support", serde(with = "BigArray"))]
     pub key: [u8; 64],
 }
 
@@ -54,7 +71,8 @@ impl_consensus_encoding!(Key64, key);
 
 // ====================================================================
 /// Confidential transaction key
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct CtKey {
     //pub dest: Key,
     /// Mask
@@ -94,7 +112,8 @@ impl_consensus_encoding!(MultisigOut, c);
 /// Diffie-Hellman info
 /// Mask and amount for transaction before Bulletproof2 and only 8 bytes hash for the amount in
 /// Bulletproof2 type
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub enum EcdhInfo {
     /// Standard format, before bp2
     Standard {
@@ -147,7 +166,8 @@ impl<S: Encoder> Encodable<S> for EcdhInfo {
 
 // ====================================================================
 /// Borromean signature for range commitment
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct BoroSig {
     /// s0 value
     pub s0: Key64,
@@ -161,7 +181,8 @@ impl_consensus_encoding!(BoroSig, s0, s1, ee);
 
 // ====================================================================
 /// Mg sig
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct MgSig {
     /// Matrice of keys
     pub ss: Vec<Vec<Key>>,
@@ -180,8 +201,9 @@ impl<S: Encoder> Encodable<S> for MgSig {
 
 // ====================================================================
 /// Range signature for range commitment
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[allow(non_snake_case)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct RangeSig {
     /// asig value
     pub asig: BoroSig,
@@ -193,8 +215,9 @@ impl_consensus_encoding!(RangeSig, asig, Ci);
 
 // ====================================================================
 /// Bulletproof format
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[allow(non_snake_case)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct Bulletproof {
     /// A value
     pub A: Key,
@@ -224,7 +247,8 @@ impl_consensus_encoding!(Bulletproof, A, S, T1, T2, taux, mu, L, R, a, b, t);
 
 // ====================================================================
 /// RingCT base signature format
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct RctSigBase {
     /// The RingCT type of signatures
     pub rct_type: RctType,
@@ -304,6 +328,7 @@ impl hash::Hashable for RctSigBase {
 // ====================================================================
 /// RingCT types
 #[derive(Debug, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub enum RctType {
     /// Null type
     Null,
@@ -356,8 +381,9 @@ impl<S: Encoder> Encodable<S> for RctType {
 
 // ====================================================================
 /// Prunable part of RingCT signature format
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[allow(non_snake_case)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct RctSigPrunable {
     /// Range signatures
     pub range_sigs: Vec<RangeSig>,
@@ -468,7 +494,8 @@ impl RctSigPrunable {
 
 // ====================================================================
 /// A RingCT signature
-#[derive(Debug)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct RctSig {
     /// The base part
     pub sig: Option<RctSigBase>,
@@ -478,7 +505,8 @@ pub struct RctSig {
 
 // ====================================================================
 /// A raw signature
-#[derive(Debug)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct Signature {
     /// c value
     pub c: Key,


### PR DESCRIPTION
Added support for serde across the board. This is hidden behind a feature flag serde_support. The old serde flag will still work and still only work for the address struct. 

Added Debug, Clone and Default derives to most structs as well. This will make it easier to integrate with code that requires those. 