### PR TITLE
Updated dependancies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,9 @@ hex = "0.4"
 byteorder = "1"
 keccak-hash = "0.3"
 base58-monero = "0.1"
-serde = { version = "1", features = ["derive"], optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 serde-big-array = {version ="0.2.0", optional = true}
-curve25519-dalek= {version ="1", features = ["serde"]}
+curve25519-dalek= {version ="2.0", features = ["serde"]}
 
 [dependencies.fixed-hash]
 version = "0.3"


### PR DESCRIPTION
Updated dalek dependancy
locked serde and dalek to a finer version.

It looks like the newer rust version breaks with serde isnt upgraded. This fixes it. 