### PR TITLE
Replace std::error::Error trait with Failure crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ base58-monero = "0.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde-big-array = {version ="0.2.0", optional = true}
 curve25519-dalek= {version ="2.0", features = ["serde"]}
+failure = "^0.1"
+failure_derive = "^0.1"
 
 [dependencies.fixed-hash]
 version = "0.3"

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -196,7 +196,7 @@ impl<'a> OwnedTxOut<'a> {
 
 /// Every transaction contains an Extra field, which is a part of transaction prefix
 ///
-/// Extra field is composed of typed sub fields of variable or fixed lenght.
+/// Extra field is composed of typed sub fields of variable or fixed length.
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct ExtraField(pub Vec<SubField>);
@@ -220,22 +220,22 @@ impl ExtraField {
 }
 
 /// Each sub-field contains a sub-field tag followed by sub-field content of fixed or variable
-/// lenght, in variable lenght case the lenght is encoded with a VarInt before the content itself.
+/// length, in variable length case the length is encoded with a VarInt before the content itself.
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub enum SubField {
-    /// Transaction public key, fixed lenght of 32 bytes
+    /// Transaction public key, fixed length of 32 bytes
     TxPublicKey(PublicKey),
     /// 255 bytes limited nonce, can contain an encrypted or unencrypted payment id, variable
-    /// lenght
+    /// length
     Nonce(Vec<u8>),
-    /// Padding size is limited to 255 null bytes, variable lenght
+    /// Padding size is limited to 255 null bytes, variable length
     Padding(u8),
-    /// Merge mining infos: `depth` and `merkle_root`, fixed lenght of one VarInt and 32 bytes hash
+    /// Merge mining infos: `depth` and `merkle_root`, fixed length of one VarInt and 32 bytes hash
     MergeMining(VarInt, hash::Hash),
-    /// Additional public keys for Subaddresses outputs, variable lenght of `n` additional public keys
+    /// Additional public keys for Subaddresses outputs, variable length of `n` additional public keys
     AdditionalPublickKey(Vec<PublicKey>),
-    /// Mysterious MinerGate, variable lenght
+    /// Mysterious MinerGate, variable length
     MysteriousMinerGate(String),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,9 @@
 #![deny(unused_mut)]
 #![deny(missing_docs)]
 
+extern crate failure;
+#[macro_use]
+extern crate failure_derive;
 #[macro_use]
 mod internal_macros;
 #[macro_use]

--- a/src/network.rs
+++ b/src/network.rs
@@ -17,37 +17,14 @@
 //!
 //! This module defines the different Monero networks and their magic bytes.
 
-use std::{error, fmt};
-
 use crate::util::address::AddressType;
 
 /// Network error types
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Fail, Debug, PartialEq, Eq)]
 pub enum Error {
     /// Invalid magic network byte
+    #[fail(display = "invalid magic byte")]
     InvalidMagicByte,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::InvalidMagicByte => f.write_str(error::Error::description(self)),
-        }
-    }
-}
-
-impl error::Error for Error {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
-            Error::InvalidMagicByte => None,
-        }
-    }
-
-    fn description(&self) -> &str {
-        match *self {
-            Error::InvalidMagicByte => "invalid magic byte",
-        }
-    }
 }
 
 /// Network type

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -47,7 +47,7 @@
 //!
 
 use std::str::FromStr;
-use std::{error, fmt};
+use std::fmt;
 
 use base58_monero::base58;
 use keccak_hash::keccak_256;
@@ -56,57 +56,26 @@ use crate::network::{self, Network};
 use crate::util::key::{KeyPair, PublicKey, ViewPair};
 
 /// Possible errors when manipulating addresses
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Fail, Debug, PartialEq, Eq)]
 pub enum Error {
     /// Invalid address magic byte
+    #[fail(display = "invalid magic byte")]
     InvalidMagicByte,
     /// Invalid payment id
+    #[fail(display = "invalid payment ID")]
     InvalidPaymentId,
     /// Missmatch checksums
+    #[fail(display = "invalid checksum")]
     InvalidChecksum,
     /// Invalid format
+    #[fail(display = "invalid format")]
     InvalidFormat,
     /// Monero base58 error
+    #[fail(display = "Base58 error: {:?}", _0)]
     Base58(base58::Error),
     /// Network error
+    #[fail(display = "Network error: {:?}", _0)]
     Network(network::Error),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::Base58(ref e) => fmt::Display::fmt(e, f),
-            Error::Network(ref e) => fmt::Display::fmt(e, f),
-            Error::InvalidMagicByte
-            | Error::InvalidPaymentId
-            | Error::InvalidChecksum
-            | Error::InvalidFormat => f.write_str(error::Error::description(self)),
-        }
-    }
-}
-
-impl error::Error for Error {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
-            Error::Base58(ref e) => Some(e),
-            Error::Network(ref e) => Some(e),
-            Error::InvalidMagicByte
-            | Error::InvalidPaymentId
-            | Error::InvalidChecksum
-            | Error::InvalidFormat => None,
-        }
-    }
-
-    fn description(&self) -> &str {
-        match *self {
-            Error::Base58(ref e) => e.description(),
-            Error::Network(ref e) => e.description(),
-            Error::InvalidMagicByte => "invalid magic byte",
-            Error::InvalidPaymentId => "invalid payment id",
-            Error::InvalidChecksum => "checksums missmatch",
-            Error::InvalidFormat => "invalid format",
-        }
-    }
 }
 
 #[doc(hidden)]

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -62,7 +62,7 @@
 use std::hash::{Hash, Hasher};
 use std::ops::{Add, Mul, Sub};
 use std::str::FromStr;
-use std::{error, fmt, ops};
+use std::{fmt, ops};
 
 use curve25519_dalek::constants::ED25519_BASEPOINT_TABLE;
 use curve25519_dalek::edwards::{CompressedEdwardsY, EdwardsPoint};
@@ -75,45 +75,20 @@ use crate::cryptonote::hash;
 use serde::{Deserialize, Serialize};
 
 /// Errors that might occur during key decoding
-#[derive(Debug, PartialEq)]
+#[derive(Fail, Debug, PartialEq)]
 pub enum Error {
-    /// Invalid input lenght
-    InvalidLenght,
+    /// Invalid input length
+    #[fail(display = "invalid length")]
+    InvalidLength,
     /// Not a canonical representation of an ed25519 scalar
+    #[fail(display = "not a canonical representation of an ed25519 scalar")]
     NotCanonicalScalar,
     /// Invalid point on the curve
+    #[fail(display = "invalid point on the curve")]
     InvalidPoint,
     /// Hex parsing error
+    #[fail(display = "Hex error: {:?}", _0)]
     Hex(hex::FromHexError),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::Hex(ref e) => fmt::Display::fmt(e, f),
-            Error::InvalidLenght | Error::NotCanonicalScalar | Error::InvalidPoint => {
-                f.write_str(error::Error::description(self))
-            }
-        }
-    }
-}
-
-impl error::Error for Error {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
-            Error::Hex(ref e) => Some(e),
-            Error::InvalidLenght | Error::NotCanonicalScalar | Error::InvalidPoint => None,
-        }
-    }
-
-    fn description(&self) -> &str {
-        match *self {
-            Error::Hex(ref e) => e.description(),
-            Error::InvalidLenght => "invalid lenght",
-            Error::NotCanonicalScalar => "not a canonical scalar",
-            Error::InvalidPoint => "invalid point",
-        }
-    }
 }
 
 #[doc(hidden)]
@@ -144,7 +119,7 @@ impl PrivateKey {
     /// Deserialize a private key from a slice
     pub fn from_slice(data: &[u8]) -> Result<PrivateKey, Error> {
         if data.len() != 32 {
-            return Err(Error::InvalidLenght);
+            return Err(Error::InvalidLength);
         }
         let mut bytes = [0u8; 32];
         bytes.copy_from_slice(data);
@@ -298,7 +273,7 @@ impl PublicKey {
     /// Deserialize a public key from a slice
     pub fn from_slice(data: &[u8]) -> Result<PublicKey, Error> {
         if data.len() != 32 {
-            return Err(Error::InvalidLenght);
+            return Err(Error::InvalidLength);
         }
         let point = CompressedEdwardsY::from_slice(data);
         match point.decompress() {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -22,48 +22,21 @@ pub mod address;
 pub mod key;
 pub mod ringct;
 
-use std::{error, fmt};
-
 use super::network;
 
 /// A general error code, other errors should implement conversions to/from this
 /// if appropriate.
-#[derive(Debug, PartialEq)]
+#[derive(Fail, Debug, PartialEq)]
 pub enum Error {
     /// Monero network error
+    #[fail(display = "Network error: {:?}", _0)]
     Network(network::Error),
     /// Monero address error
+    #[fail(display = "Address error: {:?}", _0)]
     Address(address::Error),
     /// Monero key error
+    #[fail(display = "Key error: {:?}", _0)]
     Key(key::Error),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::Network(ref e) => fmt::Display::fmt(e, f),
-            Error::Address(ref e) => fmt::Display::fmt(e, f),
-            Error::Key(ref e) => fmt::Display::fmt(e, f),
-        }
-    }
-}
-
-impl error::Error for Error {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
-            Error::Network(ref e) => Some(e),
-            Error::Address(ref e) => Some(e),
-            Error::Key(ref e) => Some(e),
-        }
-    }
-
-    fn description(&self) -> &str {
-        match *self {
-            Error::Network(ref e) => e.description(),
-            Error::Address(ref e) => e.description(),
-            Error::Key(ref e) => e.description(),
-        }
-    }
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
Error trait from the standard library has been deprecated.

Failure is the de-facto replacement. Derives `Fail` trait for all
internal error types.