### PR TITLE
Implement display for most stucts

### DIFF
--- a/src/blockdata/block.rs
+++ b/src/blockdata/block.rs
@@ -23,6 +23,7 @@ use crate::consensus::encode::VarInt;
 use crate::cryptonote::hash;
 #[cfg(feature = "serde_support")]
 use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Error, Formatter};
 
 /// Monero block header
 #[derive(Debug, Clone, Default)]
@@ -38,6 +39,16 @@ pub struct BlockHeader {
     pub prev_id: hash::Hash,
     /// Nonce
     pub nonce: u32,
+}
+
+impl Display for BlockHeader {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
+        writeln!(fmt, "Major version: {}", self.major_version,)?;
+        writeln!(fmt, "Minor version: {}", self.minor_version,)?;
+        writeln!(fmt, "Timestamp: {}", self.timestamp,)?;
+        writeln!(fmt, "Previous id: {}", self.prev_id,)?;
+        writeln!(fmt, "Nonce: {}", self.nonce,)
+    }
 }
 
 impl_consensus_encoding!(
@@ -59,6 +70,17 @@ pub struct Block {
     pub miner_tx: Transaction,
     /// List of included transactions
     pub tx_hashes: Vec<hash::Hash>,
+}
+
+impl Display for Block {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), Error> {
+        writeln!(fmt, "Block header: {}", self.header,)?;
+        writeln!(fmt, "Miner tx: {}", self.miner_tx)?;
+        for tx in &self.tx_hashes {
+            writeln!(fmt, "tx: {}", tx,)?;
+        }
+        Ok(())
+    }
 }
 
 impl_consensus_encoding!(Block, header, miner_tx, tx_hashes);

--- a/src/consensus/encode.rs
+++ b/src/consensus/encode.rs
@@ -179,7 +179,7 @@ macro_rules! encoder_fn {
         fn $name(&mut self, v: $val_type) -> Result<(), Error> {
             WriteBytesExt::$writefn::<LittleEndian>(self, v).map_err(Error::Io)
         }
-    }
+    };
 }
 
 macro_rules! decoder_fn {
@@ -188,7 +188,7 @@ macro_rules! decoder_fn {
         fn $name(&mut self) -> Result<$val_type, Error> {
             ReadBytesExt::$readfn::<LittleEndian>(self).map_err(Error::Io)
         }
-    }
+    };
 }
 
 impl<W: Write> Encoder for W {

--- a/src/util/ringct.rs
+++ b/src/util/ringct.rs
@@ -19,6 +19,7 @@
 //!
 
 use std::fmt;
+use std::fmt::{Display, Error as FmtError, Formatter};
 
 use crate::consensus::encode::{self, serialize, Decodable, Decoder, Encodable, Encoder, VarInt};
 use crate::cryptonote::hash;
@@ -79,6 +80,12 @@ pub struct CtKey {
     pub mask: Key,
 }
 
+impl Display for CtKey {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), FmtError> {
+        writeln!(fmt, "Mask: {}", self.mask)
+    }
+}
+
 impl_consensus_encoding!(CtKey, mask);
 
 // ====================================================================
@@ -127,6 +134,23 @@ pub enum EcdhInfo {
         /// Amount value
         amount: hash::Hash8,
     },
+}
+
+impl Display for EcdhInfo {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), FmtError> {
+        match self {
+            EcdhInfo::Standard { mask, amount } => {
+                writeln!(fmt, "Standard")?;
+                writeln!(fmt, "Mask: {}", mask)?;
+                writeln!(fmt, "Amount: {}", amount)?;
+            }
+            EcdhInfo::Bulletproof2 { amount } => {
+                writeln!(fmt, "Bulletproof2")?;
+                writeln!(fmt, "Amount: {}", amount)?;
+            }
+        };
+        Ok(())
+    }
 }
 
 impl EcdhInfo {
@@ -264,6 +288,23 @@ pub struct RctSigBase {
     pub out_pk: Vec<CtKey>,
 }
 
+impl Display for RctSigBase {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), FmtError> {
+        writeln!(fmt, "RCT type: {}", self.rct_type)?;
+        writeln!(fmt, "Tx fee: {}", self.txn_fee)?;
+        for out in &self.pseudo_outs {
+            writeln!(fmt, "Pseudo_out: {}", out)?;
+        }
+        for ecdh in &self.ecdh_info {
+            writeln!(fmt, "Ecdh_info: {}", ecdh)?;
+        }
+        for out in &self.out_pk {
+            writeln!(fmt, "Out_pk: {}", out)?;
+        }
+        Ok(())
+    }
+}
+
 impl RctSigBase {
     /// Decode a RingCT base signature given the number of inputs and outputs of the transaction
     pub fn consensus_decode<D: Decoder>(
@@ -346,6 +387,19 @@ pub enum RctType {
     Bulletproof,
     /// Bulletproof2 type, used in the current network
     Bulletproof2,
+}
+
+impl Display for RctType {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), FmtError> {
+        let rct_type = match self {
+            RctType::Null => "Null",
+            RctType::Full => "Full",
+            RctType::Simple => "Simple",
+            RctType::Bulletproof => "Bulletproof",
+            RctType::Bulletproof2 => "Bulletproof2",
+        };
+        write!(fmt, "{}", rct_type)
+    }
 }
 
 impl RctType {
@@ -509,6 +563,16 @@ pub struct RctSig {
     pub p: Option<RctSigPrunable>,
 }
 
+impl Display for RctSig {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), FmtError> {
+        match &self.sig {
+            Some(v) => writeln!(fmt, "Signature: {}", v)?,
+            None => writeln!(fmt, "Signature: None")?,
+        };
+        Ok(())
+    }
+}
+
 // ====================================================================
 /// A raw signature
 #[derive(Debug, Clone)]
@@ -518,6 +582,13 @@ pub struct Signature {
     pub c: Key,
     /// r value
     pub r: Key,
+}
+
+impl Display for Signature {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), FmtError> {
+        writeln!(fmt, "C: {}", self.c)?;
+        writeln!(fmt, "R: {}", self.r)
+    }
 }
 
 impl_consensus_encoding!(Signature, c, r);


### PR DESCRIPTION
I implemented display for most of the struct. 
I know too little of monero to know what is actually good info to display. So I tried to balance it out what I think would be good info. 

This will now allow a user to call `println!("block: {}", block);` and it should display it in an ergonomical fashion. 