### PR TITLE
Replace deprecated failure crate with thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,7 @@ base58-monero = "0.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde-big-array = { version ="0.2.0", optional = true }
 curve25519-dalek = { version ="2.0", features = ["serde"] }
-failure = "^0.1"
-failure_derive = "^0.1"
+thiserror = "^1.0.20"
 
 [dependencies.fixed-hash]
 version = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,9 +42,6 @@
 #![deny(unused_mut)]
 #![deny(missing_docs)]
 
-extern crate failure;
-#[macro_use]
-extern crate failure_derive;
 #[macro_use]
 mod internal_macros;
 #[macro_use]

--- a/src/network.rs
+++ b/src/network.rs
@@ -18,12 +18,13 @@
 //! This module defines the different Monero networks and their magic bytes.
 
 use crate::util::address::AddressType;
+use thiserror::Error;
 
 /// Network error types
-#[derive(Fail, Debug, PartialEq, Eq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum Error {
     /// Invalid magic network byte
-    #[fail(display = "invalid magic byte")]
+    #[error("invalid magic byte")]
     InvalidMagicByte,
 }
 

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -55,41 +55,29 @@ use keccak_hash::keccak_256;
 use crate::network::{self, Network};
 use crate::util::key::{KeyPair, PublicKey, ViewPair};
 
+use thiserror::Error;
+
 /// Possible errors when manipulating addresses
-#[derive(Fail, Debug, PartialEq, Eq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum Error {
     /// Invalid address magic byte
-    #[fail(display = "invalid magic byte")]
+    #[error("invalid magic byte")]
     InvalidMagicByte,
     /// Invalid payment id
-    #[fail(display = "invalid payment ID")]
+    #[error("invalid payment ID")]
     InvalidPaymentId,
     /// Missmatch checksums
-    #[fail(display = "invalid checksum")]
+    #[error("invalid checksum")]
     InvalidChecksum,
     /// Invalid format
-    #[fail(display = "invalid format")]
+    #[error("invalid format")]
     InvalidFormat,
     /// Monero base58 error
-    #[fail(display = "Base58 error: {:?}", _0)]
-    Base58(base58::Error),
+    #[error("Base58 error: {0}")]
+    Base58(#[from] base58::Error),
     /// Network error
-    #[fail(display = "Network error: {:?}", _0)]
-    Network(network::Error),
-}
-
-#[doc(hidden)]
-impl From<base58::Error> for Error {
-    fn from(e: base58::Error) -> Error {
-        Error::Base58(e)
-    }
-}
-
-#[doc(hidden)]
-impl From<network::Error> for Error {
-    fn from(e: network::Error) -> Error {
-        Error::Network(e)
-    }
+    #[error("Network error: {0}")]
+    Network(#[from] network::Error),
 }
 
 /// Address type: standard, integrated, or sub address

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -71,31 +71,26 @@ use curve25519_dalek::scalar::Scalar;
 use crate::consensus::encode::{self, Decodable, Decoder, Encodable, Encoder};
 use crate::cryptonote::hash;
 
+use thiserror::Error;
+
 #[cfg(feature = "serde_support")]
 use serde::{Deserialize, Serialize};
 
 /// Errors that might occur during key decoding
-#[derive(Fail, Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq)]
 pub enum Error {
     /// Invalid input length
-    #[fail(display = "invalid length")]
+    #[error("invalid length")]
     InvalidLength,
     /// Not a canonical representation of an ed25519 scalar
-    #[fail(display = "not a canonical representation of an ed25519 scalar")]
+    #[error("not a canonical representation of an ed25519 scalar")]
     NotCanonicalScalar,
     /// Invalid point on the curve
-    #[fail(display = "invalid point on the curve")]
+    #[error("invalid point on the curve")]
     InvalidPoint,
     /// Hex parsing error
-    #[fail(display = "Hex error: {:?}", _0)]
-    Hex(hex::FromHexError),
-}
-
-#[doc(hidden)]
-impl From<hex::FromHexError> for Error {
-    fn from(e: hex::FromHexError) -> Error {
-        Error::Hex(e)
-    }
+    #[error("Hex error: {0}")]
+    Hex(#[from] hex::FromHexError),
 }
 
 /// Monero private key

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -23,39 +23,19 @@ pub mod key;
 pub mod ringct;
 
 use super::network;
+use thiserror::Error;
 
 /// A general error code, other errors should implement conversions to/from this
 /// if appropriate.
-#[derive(Fail, Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq)]
 pub enum Error {
     /// Monero network error
-    #[fail(display = "Network error: {:?}", _0)]
-    Network(network::Error),
+    #[error("Network error: {0}")]
+    Network(#[from] network::Error),
     /// Monero address error
-    #[fail(display = "Address error: {:?}", _0)]
-    Address(address::Error),
+    #[error("Address error: {0}")]
+    Address(#[from] address::Error),
     /// Monero key error
-    #[fail(display = "Key error: {:?}", _0)]
-    Key(key::Error),
-}
-
-#[doc(hidden)]
-impl From<network::Error> for Error {
-    fn from(e: network::Error) -> Error {
-        Error::Network(e)
-    }
-}
-
-#[doc(hidden)]
-impl From<address::Error> for Error {
-    fn from(e: address::Error) -> Error {
-        Error::Address(e)
-    }
-}
-
-#[doc(hidden)]
-impl From<key::Error> for Error {
-    fn from(e: key::Error) -> Error {
-        Error::Key(e)
-    }
+    #[error("Key error: {0}")]
+    Key(#[from] key::Error),
 }


### PR DESCRIPTION
Greetings @h4sh3d !

This commit removes the deprecated `failure` crate in favour of `thiserror` - fixes #19  

Tests pass successfully, but please let me know if it doesn't work as intended! 