### PR TITLE
Add several trait implementations for `PrivateKey`, `PublicKey` and `ringct::{Key, Key64}`

### DIFF
--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -63,6 +63,7 @@ use std::hash::{Hash, Hasher};
 use std::ops::{Add, Mul, Sub};
 use std::str::FromStr;
 use std::{fmt, io, ops};
+use std::convert::TryFrom;
 
 use curve25519_dalek::constants::ED25519_BASEPOINT_TABLE;
 use curve25519_dalek::edwards::{CompressedEdwardsY, EdwardsPoint};
@@ -132,6 +133,22 @@ impl PrivateKey {
     /// Create a secret key from a raw curve25519 scalar
     pub fn from_scalar(scalar: Scalar) -> PrivateKey {
         PrivateKey { scalar }
+    }
+}
+
+impl TryFrom<[u8; 32]> for PrivateKey {
+    type Error = Error;
+
+    fn try_from(value: [u8; 32]) -> Result<Self, Self::Error> {
+        Self::from_slice(&value)
+    }
+}
+
+impl TryFrom<&[u8]> for PrivateKey {
+    type Error = Error;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        Self::from_slice(value)
     }
 }
 
@@ -295,6 +312,22 @@ impl PublicKey {
         self.point
             .decompress()
             .expect("PublicKey Can only be created if a valid point is found. QED")
+    }
+}
+
+impl TryFrom<[u8; 32]> for PublicKey {
+    type Error = Error;
+
+    fn try_from(value: [u8; 32]) -> Result<Self, Self::Error> {
+        Self::from_slice(&value)
+    }
+}
+
+impl TryFrom<&[u8]> for PublicKey {
+    type Error = Error;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        Self::from_slice(value)
     }
 }
 

--- a/src/util/ringct.rs
+++ b/src/util/ringct.rs
@@ -49,7 +49,7 @@ pub enum Error {
 
 // ====================================================================
 /// Raw 32 bytes key
-#[derive(Clone)]
+#[derive(Clone, Copy, PartialEq, Hash)]
 #[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct Key {
     /// The actual key
@@ -60,9 +60,17 @@ impl_hex_display!(Key, key);
 
 impl_consensus_encoding!(Key, key);
 
+impl From<[u8; 32]> for Key {
+    fn from(key: [u8; 32]) -> Self {
+        Self {
+            key
+        }
+    }
+}
+
 // ====================================================================
 /// Raw 64 bytes key
-#[derive(Clone)]
+#[derive(Clone, Copy, PartialEq, Hash)]
 #[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct Key64 {
     /// The actual key
@@ -74,9 +82,17 @@ impl_hex_display!(Key64, key);
 
 impl_consensus_encoding!(Key64, key);
 
+impl From<[u8; 64]> for Key64 {
+    fn from(key: [u8; 64]) -> Self {
+        Self {
+            key
+        }
+    }
+}
+
 // ====================================================================
 /// Confidential transaction key
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Hash)]
 #[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct CtKey {
     //pub dest: Key,


### PR DESCRIPTION
These are useful when trying to write code that is generic over constructing / deserializing things from byte slices and arrays.

I wasn't quite sure how invasive I should be in terms of the derives (most of the types in the `ringct` module could probably use a couple of derives) so I only added the ones that I need at the moment.