### PR TITLE
Replace keccak-hash with tiny-keccak

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ strict_encoding_support = ["strict_encoding"]
 [dependencies]
 hex = "0.4.3"
 hex-literal = "0.3.1"
-keccak-hash = "0.7.0"
+tiny-keccak = { version = "2", features = ["keccak"] }
 base58-monero = { version = "0.3", default-features = false }
 serde = { version = "1.0.124", features = ["derive"], optional = true }
 serde-big-array = { version = "0.3.2", optional = true }

--- a/src/cryptonote/hash.rs
+++ b/src/cryptonote/hash.rs
@@ -23,7 +23,7 @@
 //!
 
 use curve25519_dalek::scalar::Scalar;
-use keccak_hash::keccak_256;
+use tiny_keccak::{Hasher, Keccak};
 
 use std::io;
 
@@ -46,9 +46,7 @@ impl Hash {
 
     /// Hash a stream of bytes with the Keccak-256 hash function.
     pub fn hash(input: &[u8]) -> Hash {
-        let mut out = [0u8; 32];
-        keccak_256(input, &mut out);
-        Hash(out)
+        Hash(keccak_256(input))
     }
 
     /// Return the 32-bytes hash array.
@@ -113,4 +111,15 @@ impl Encodable for Hash8 {
     fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
         self.0.consensus_encode(s)
     }
+}
+
+/// Compute the Keccak256 hash of the provided byte-slice.
+pub fn keccak_256(input: &[u8]) -> [u8; 32] {
+    let mut keccak = Keccak::v256();
+
+    let mut out = [0u8; 32];
+    keccak.update(input);
+    keccak.finalize(&mut out);
+
+    out
 }

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -41,8 +41,8 @@ use std::fmt;
 use std::str::FromStr;
 
 use base58_monero::base58;
-use keccak_hash::keccak_256;
 
+use crate::cryptonote::hash::keccak_256;
 use crate::network::{self, Network};
 use crate::util::key::{KeyPair, PublicKey, ViewPair};
 
@@ -229,12 +229,11 @@ impl Address {
         let public_view =
             PublicKey::from_slice(&bytes[33..65]).map_err(|_| Error::InvalidFormat)?;
 
-        let mut verify_checksum = [0u8; 32];
         let (checksum_bytes, checksum) = match addr_type {
             AddressType::Standard | AddressType::SubAddress => (&bytes[0..65], &bytes[65..69]),
             AddressType::Integrated(_) => (&bytes[0..73], &bytes[73..77]),
         };
-        keccak_256(checksum_bytes, &mut verify_checksum);
+        let verify_checksum = keccak_256(checksum_bytes);
         if &verify_checksum[0..4] != checksum {
             return Err(Error::InvalidChecksum);
         }
@@ -256,8 +255,7 @@ impl Address {
             bytes.extend_from_slice(&payment_id.0);
         }
 
-        let mut checksum = [0u8; 32];
-        keccak_256(bytes.as_slice(), &mut checksum);
+        let checksum = keccak_256(bytes.as_slice());
         bytes.extend_from_slice(&checksum[0..4]);
         bytes
     }


### PR DESCRIPTION
The dependency footprint of tiny-keccak is smaller and it also has
a more versatile API that allows streaming bytes into the hash
engine.

Before:

❯ cargo tree | wc -l
56

After:

❯ cargo tree | wc -l
48