### PR TITLE
Add function for computing the signature hash of a transaction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ default = ["full"]
 full = ["fixed-hash/std", "fixed-hash/rand"]
 serde_support = ["serde", "serde-big-array"]
 strict_encoding_support = ["strict_encoding"]
+experimental = [ ]
 
 [dependencies]
 hex = "0.4.3"

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -27,14 +27,14 @@ use crate::cryptonote::subaddress::Index;
 use crate::util::key::{KeyPair, PrivateKey, PublicKey, ViewPair};
 use crate::util::ringct::{Opening, RctSig, RctSigBase, RctSigPrunable, RctType, Signature};
 
+use curve25519_dalek::edwards::{CompressedEdwardsY, EdwardsPoint};
+use curve25519_dalek::scalar::Scalar;
 use hex::encode as hex_encode;
 use thiserror::Error;
 
 use std::ops::Range;
 use std::{fmt, io};
 
-use curve25519_dalek::edwards::{CompressedEdwardsY, EdwardsPoint};
-use curve25519_dalek::scalar::Scalar;
 #[cfg(feature = "serde_support")]
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
~Includes https://github.com/monero-rs/monero-rs/pull/40 until merged, hence draft for now.~

~What do you think is the best way to test this?
The original implementation is [here](https://github.com/monero-project/monero/blob/dcba757dd283a3396120f0df90fe746e3ec02292/src/ringct/rctSigs.cpp#L573-L631) but it doesn't include any unit tests (presumably because constructing a TX is quite the effort and half the transaction is hashed here ...)~

~We can add tests that "freeze" the current implementation but that might be as good as it gets.~

Once we upstream the full CLSAG implementation, it might be easier because we can take mainnet transactions and verify their signature which includes producing the correct message hash.

TODO:

- [x] Rebase onto latest main
- [x] Audit codebase and use `thiserror` for all errors
- [x] Add check for `RctType` in `signature_hash` function and document better that it works for CLSAG only atm.
- [x] Feature-flag `signature_hash` with `experimental`