### PR TITLE
Expose all confidential information of output through `OwnedTxOut`

### DIFF
--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -221,7 +221,7 @@ impl<'a> OwnedTxOut<'a> {
     }
 
     /// Retreive the public keys, if any.
-    pub fn get_pubkeys(&self) -> Option<Vec<PublicKey>> {
+    pub fn pubkeys(&self) -> Option<Vec<PublicKey>> {
         self.out.get_pubkeys()
     }
 

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -185,17 +185,33 @@ impl TxOut {
 ///
 #[derive(Debug)]
 pub struct OwnedTxOut<'a> {
-    /// Index of the output in the transaction.
-    pub index: usize,
-    /// A reference to the actual redeemable output.
-    pub out: &'a TxOut,
-    /// Index of the key pair to use, can be `0/0` for main address.
-    pub sub_index: Index,
-    /// The associated transaction public key.
-    pub tx_pubkey: PublicKey,
+    index: usize,
+    out: &'a TxOut,
+    sub_index: Index,
+    tx_pubkey: PublicKey,
 }
 
 impl<'a> OwnedTxOut<'a> {
+    /// Returns the index of this output in the transaction
+    pub fn index(&self) -> usize {
+        self.index
+    }
+
+    /// Returns a reference to the actual redeemable output.
+    pub fn out(&self) -> &'a TxOut {
+        &self.out
+    }
+
+    /// Returns the index of the key pair to use, can be `0/0` for main address.
+    pub fn sub_index(&self) -> Index {
+        self.sub_index
+    }
+
+    /// Returns the associated transaction public key.
+    pub fn tx_pubkey(&self) -> PublicKey {
+        self.tx_pubkey
+    }
+
     /// Retreive the public keys, if any.
     pub fn get_pubkeys(&self) -> Option<Vec<PublicKey>> {
         self.out.get_pubkeys()

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -22,19 +22,19 @@
 
 use crate::consensus::encode::{self, serialize, Decodable, Encodable, VarInt};
 use crate::cryptonote::hash;
-use crate::cryptonote::onetime_key::{KeyGenerator, KeyRecoverer, SubKeyChecker};
+use crate::cryptonote::onetime_key::{KeyRecoverer, SubKeyChecker};
 use crate::cryptonote::subaddress::Index;
 use crate::util::amount::RecoveryError;
-use crate::util::key::{KeyPair, PrivateKey, PublicKey, ViewPair, H};
-use crate::util::ringct::{EcdhInfo, RctSig, RctSigBase, RctSigPrunable, RctType, Signature};
+use crate::util::key::{KeyPair, PrivateKey, PublicKey, ViewPair};
+use crate::util::ringct::{RctSig, RctSigBase, RctSigPrunable, RctType, Signature};
 
-use curve25519_dalek::scalar::Scalar;
 use hex::encode as hex_encode;
 use thiserror::Error;
 
-use std::convert::TryInto;
 use std::ops::Range;
 use std::{fmt, io};
+
+use curve25519_dalek::edwards::CompressedEdwardsY;
 
 #[cfg(feature = "serde_support")]
 use serde::{Deserialize, Serialize};
@@ -501,65 +501,13 @@ impl Transaction {
             .get(out.index)
             .ok_or(RecoveryError::IndexOutOfRange)?;
 
-        let shared_key = KeyGenerator::from_key(view_pair, out.tx_pubkey).get_rvn_scalar(out.index);
+        let commitment = CompressedEdwardsY(sig.out_pk[out.index].mask.key)
+            .decompress()
+            .ok_or(RecoveryError::InvalidCommitment)?;
 
-        let (commitment_mask, amount) = match ecdh_info {
-            // ecdhDecode in rctOps.cpp else
-            EcdhInfo::Standard { mask, amount } => {
-                let shared_sec1 = hash::Hash::hash(shared_key.as_bytes()).to_bytes();
-                let shared_sec2 = hash::Hash::hash(&shared_sec1).to_bytes();
-                let mask_scalar = Scalar::from_bytes_mod_order(mask.key)
-                    - Scalar::from_bytes_mod_order(shared_sec1);
-
-                let amount_scalar = Scalar::from_bytes_mod_order(amount.key)
-                    - Scalar::from_bytes_mod_order(shared_sec2);
-                // get first 64 bits (d2b in rctTypes.cpp)
-                let amount_significant_bytes = amount_scalar.to_bytes()[0..8]
-                    .try_into()
-                    .expect("Can't fail");
-                let amount = u64::from_le_bytes(amount_significant_bytes);
-                (mask_scalar, amount)
-            }
-            // ecdhDecode in rctOps.cpp if (v2)
-            EcdhInfo::Bulletproof { amount } => {
-                // genCommitmentMask in .cpp
-                let mut commitment_key = "commitment_mask".as_bytes().to_vec();
-                commitment_key.extend(shared_key.as_bytes());
-                // yt in Z2M p 53
-                let mask_scalar = Scalar::from_bytes_mod_order(
-                    hash::Hash::hash(&commitment_key).to_fixed_bytes(),
-                );
-                // ecdhHash in .cpp
-                let mut amount_key = "amount".as_bytes().to_vec();
-                amount_key.extend(shared_key.as_bytes());
-
-                // Hn("amount", Hn(rKbv,t))
-                let hash_shared_key = hash::Hash::hash(&amount_key).to_fixed_bytes();
-                let hash_shared_key_significant_bytes = hash_shared_key[0..8]
-                    .try_into()
-                    .expect("hash_shared_key create above has 32 bytes");
-
-                // bt in Z2M and masked.amount in .cpp
-                let masked_amount = amount.0; // 8 bytes
-
-                // amount_t = bt XOR Hn("amount", Hn("amount", Hn(rKbv,t)))
-                // xor8(masked.amount, ecdhHash(sharedSec)); in .cpp
-                let amount = u64::from_le_bytes(masked_amount)
-                    ^ u64::from_le_bytes(hash_shared_key_significant_bytes);
-
-                (mask_scalar, amount)
-            }
-        };
-
-        let blinding_factor =
-            PublicKey::from_private_key(&PrivateKey::from_scalar(commitment_mask));
-        let committed_amount = H * &PrivateKey::from_scalar(Scalar::from(amount));
-        let expected_commitment = blinding_factor + committed_amount;
-        let actual_commitment = PublicKey::from_slice(&sig.out_pk[out.index].mask.key);
-
-        if actual_commitment != Ok(expected_commitment) {
-            return Err(RecoveryError::InvalidCommitment);
-        }
+        let (amount, _) = ecdh_info
+            .open_commitment(view_pair, &out.tx_pubkey, out.index, &commitment)
+            .ok_or(RecoveryError::InvalidCommitment)?;
 
         Ok(amount)
     }

--- a/src/util/amount.rs
+++ b/src/util/amount.rs
@@ -28,23 +28,6 @@ use std::str::FromStr;
 
 use thiserror::Error;
 
-/// Potential errors encountered when recovering the amount of an [`OwnedTxOut`].
-///
-/// [`OwnedTxOut`]: crate::blockdata::transaction::OwnedTxOut
-///
-#[derive(Error, Debug, PartialEq)]
-pub enum RecoveryError {
-    /// Index of output is out of range.
-    #[error("The index is out of range")]
-    IndexOutOfRange,
-    /// Missing signature for the output.
-    #[error("Missing signature for the output")]
-    MissingSignature,
-    /// Invalid commitment.
-    #[error("Invalid commitment")]
-    InvalidCommitment,
-}
-
 /// A set of denominations in which amounts can be expressed.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Denomination {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -47,9 +47,6 @@ pub enum Error {
     /// Monero transaction error.
     #[error("Transaction error: {0}")]
     Transaction(#[from] transaction::Error),
-    /// Monero amount recovery error.
-    #[error("Amount recovery error: {0}")]
-    AmountRecovery(#[from] amount::RecoveryError),
     /// Monero amount parsing error.
     #[error("Amount parsing error: {0}")]
     AmountParsing(#[from] amount::ParsingError),

--- a/src/util/ringct.rs
+++ b/src/util/ringct.rs
@@ -169,7 +169,7 @@ impl EcdhInfo {
         tx_pubkey: &PublicKey,
         index: usize,
         candidate_commitment: &EdwardsPoint,
-    ) -> Option<(u64, Scalar)> {
+    ) -> Option<Opening> {
         let shared_key = KeyGenerator::from_key(view_pair, *tx_pubkey).get_rvn_scalar(index);
 
         let (amount, blinding_factor) = match self {
@@ -207,8 +207,23 @@ impl EcdhInfo {
             return None;
         }
 
-        Some((amount, blinding_factor))
+        Some(Opening {
+            amount,
+            blinding_factor,
+            commitment: expected_commitment,
+        })
     }
+}
+
+/// The result of opening the commitment inside the transaction.
+#[derive(Debug)]
+pub struct Opening {
+    /// The original amount of the output.
+    pub amount: u64,
+    /// The blinding factor used to blind the amount.
+    pub blinding_factor: Scalar,
+    /// The commitment used to verify the blinded amount.
+    pub commitment: EdwardsPoint,
 }
 
 fn xor_amount(amount: [u8; 8], shared_key: Scalar) -> [u8; 8] {

--- a/src/util/ringct.rs
+++ b/src/util/ringct.rs
@@ -24,13 +24,21 @@ use std::{fmt, io};
 
 use crate::consensus::encode::{self, serialize, Decodable, Encodable, VarInt};
 use crate::cryptonote::hash;
+use crate::cryptonote::onetime_key::KeyGenerator;
+use crate::util::key::H;
+use crate::{PublicKey, ViewPair};
 
 #[cfg(feature = "serde_support")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "serde_support")]
 use serde_big_array_unchecked_docs::*;
 
+use curve25519_dalek::constants::ED25519_BASEPOINT_POINT;
+use curve25519_dalek::edwards::EdwardsPoint;
+use curve25519_dalek::scalar::Scalar;
 use thiserror::Error;
+
+use std::convert::TryInto;
 
 /// Serde support for array's bigger than 32 items.
 #[allow(missing_docs)]
@@ -151,6 +159,81 @@ pub enum EcdhInfo {
         /// Amount value.
         amount: hash::Hash8,
     },
+}
+
+impl EcdhInfo {
+    /// Opens the commitment and verifies it against the given one.
+    pub fn open_commitment(
+        &self,
+        view_pair: &ViewPair,
+        tx_pubkey: &PublicKey,
+        index: usize,
+        candidate_commitment: &EdwardsPoint,
+    ) -> Option<(u64, Scalar)> {
+        let shared_key = KeyGenerator::from_key(view_pair, *tx_pubkey).get_rvn_scalar(index);
+
+        let (amount, blinding_factor) = match self {
+            // ecdhDecode in rctOps.cpp else
+            EcdhInfo::Standard { mask, amount } => {
+                let shared_sec1 = hash::Hash::hash(shared_key.as_bytes()).to_bytes();
+                let shared_sec2 = hash::Hash::hash(&shared_sec1).to_bytes();
+                let mask_scalar = Scalar::from_bytes_mod_order(mask.key)
+                    - Scalar::from_bytes_mod_order(shared_sec1);
+
+                let amount_scalar = Scalar::from_bytes_mod_order(amount.key)
+                    - Scalar::from_bytes_mod_order(shared_sec2);
+                // get first 64 bits (d2b in rctTypes.cpp)
+                let amount_significant_bytes = amount_scalar.to_bytes()[0..8]
+                    .try_into()
+                    .expect("Can't fail");
+                let amount = u64::from_le_bytes(amount_significant_bytes);
+                (amount, mask_scalar)
+            }
+            // ecdhDecode in rctOps.cpp if (v2)
+            EcdhInfo::Bulletproof { amount } => {
+                let amount = xor_amount(amount.0, shared_key.scalar);
+                let mask = mask(shared_key.scalar);
+
+                (u64::from_le_bytes(amount), mask)
+            }
+        };
+
+        let amount_scalar = Scalar::from(amount);
+
+        let expected_commitment = ED25519_BASEPOINT_POINT * blinding_factor
+            + H.point.decompress().unwrap() * amount_scalar;
+
+        if &expected_commitment != candidate_commitment {
+            return None;
+        }
+
+        Some((amount, blinding_factor))
+    }
+}
+
+fn xor_amount(amount: [u8; 8], shared_key: Scalar) -> [u8; 8] {
+    // ecdhHash in .cpp
+    let mut amount_key = b"amount".to_vec();
+    amount_key.extend(shared_key.as_bytes());
+
+    // Hn("amount", Hn(rKbv,t))
+    let hash_shared_key = hash::Hash::hash(&amount_key).to_fixed_bytes();
+    let hash_shared_key_significant_bytes = hash_shared_key[0..8]
+        .try_into()
+        .expect("hash_shared_key create above has 32 bytes");
+
+    // amount_t = bt XOR Hn("amount", Hn("amount", Hn(rKbv,t)))
+    // xor8(masked.amount, ecdhHash(sharedSec)); in .cpp
+    (u64::from_le_bytes(amount) ^ u64::from_le_bytes(hash_shared_key_significant_bytes))
+        .to_le_bytes()
+}
+
+fn mask(scalar: Scalar) -> Scalar {
+    let mut commitment_key = b"commitment_mask".to_vec();
+    commitment_key.extend(scalar.as_bytes());
+
+    // yt in Z2M p 53
+    hash::Hash::hash_to_scalar(&commitment_key).scalar
 }
 
 impl fmt::Display for EcdhInfo {

--- a/tests/recover_outputs.rs
+++ b/tests/recover_outputs.rs
@@ -33,7 +33,7 @@ fn recover_output_and_amount() {
     };
 
     // Get all owned output for sub-addresses in range of 0-1 major index and 0-2 minor index
-    let owned_outputs = tx.prefix.check_outputs(&view_pair, 0..2, 0..3).unwrap();
+    let owned_outputs = tx.check_outputs(&view_pair, 0..2, 0..3).unwrap();
 
     assert_eq!(owned_outputs.len(), 1);
     let out = owned_outputs.get(0).unwrap();
@@ -49,7 +49,7 @@ fn recover_output_and_amount() {
         format!("{}", PublicKey::from_private_key(&private_key))
     );
 
-    let amount = tx.get_amount(&view_pair, &out);
-    assert!(amount.is_ok());
+    let amount = out.amount();
+    assert!(amount.is_some());
     assert_eq!(amount.unwrap(), 7000000000);
 }


### PR DESCRIPTION
The first 4 patches are refactorings.
The last one adds the actual functionality.

If the signatures are present in the transaction struct, we unblind and extract all possible information for a specific output. We will need this functionality once we upstream bulletproof and clsag functionality.