### PR TITLE
Adds fallible try_serialize

### DIFF
--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -34,5 +34,5 @@ pub mod endian;
 pub mod strict_encode;
 
 pub use self::encode::{
-    deserialize, serialize, serialize_hex, Decodable, Encodable, ReadExt, WriteExt,
+    deserialize, serialize, serialize_hex, try_serialize, Decodable, Encodable, ReadExt, WriteExt,
 };


### PR DESCRIPTION
Add a fallible `try_serialize` function that returns an error if the underlying `Encodable` impl errors

This is useful in cases the user may not be/want to be aware of all failure case for applicable implementations
of `Encodable`. With untrusted input, without protections from the user, `serialize` allows external parties to 
cause a panic. `try_serialize` forces the user to consider this.

For example, passing `TxIn::ToScript` causes a panic in `serialize`.