### PR TITLE
Don't use io::Cursor for implementing `Encodable` on `ExtraField`

### DIFF
--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -605,11 +605,11 @@ impl Decodable for ExtraField {
 
 impl Encodable for ExtraField {
     fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
-        let mut encoder = io::Cursor::new(vec![]);
+        let mut buffer = Vec::new();
         for field in self.0.iter() {
-            field.consensus_encode(&mut encoder)?;
+            field.consensus_encode(&mut buffer)?;
         }
-        encoder.into_inner().consensus_encode(s)
+        buffer.consensus_encode(s)
     }
 }
 


### PR DESCRIPTION
Implementations of `Encodable` should never fail unless the underlying
encoder fails. The implementation of `io::Write` for `Vec<u8>` is
easier to audit for this invariant than `io::Cursor`. Use `Vec<u8>`
instead of `io::Cursor`.

Found while reviewing https://github.com/monero-rs/monero-rs/pull/48.