### PR TITLE
Remove unused TxIn variants and seal Encodable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ serde-big-array = { version = "0.3.2", optional = true }
 curve25519-dalek = { version = "3.0.2" }
 thiserror = "1.0.24"
 strict_encoding = { version = "1.2", optional = true }
+sealed = "0.3"
 
 [dependencies.fixed-hash]
 version = "0.7.0"

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -88,10 +88,6 @@ pub enum TxIn {
         /// The corresponding key image of the output.
         k_image: KeyImage,
     },
-    /// Input from script output, not used.
-    ToScript,
-    /// Input from script hash output, not used.
-    ToScriptHash,
 }
 
 /// Type of output formats, only [`TxOutTarget::ToKey`] is used, other formats are legacy to the
@@ -839,10 +835,6 @@ impl Encodable for TxIn {
                 len += key_offsets.consensus_encode(s)?;
                 Ok(len + k_image.consensus_encode(s)?)
             }
-            _ => Err(io::Error::new(
-                io::ErrorKind::Interrupted,
-                Error::ScriptNotSupported,
-            )),
         }
     }
 }

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -20,7 +20,7 @@
 //! private view key and public spend key (view key-pair: [`ViewPair`]).
 //!
 
-use crate::consensus::encode::{self, serialize, Decodable, Encodable, VarInt};
+use crate::consensus::encode::{self, serialize, Decodable, VarInt};
 use crate::cryptonote::hash;
 use crate::cryptonote::onetime_key::{KeyRecoverer, SubKeyChecker};
 use crate::cryptonote::subaddress::Index;
@@ -30,6 +30,7 @@ use crate::util::ringct::{Opening, RctSig, RctSigBase, RctSigPrunable, RctType, 
 use curve25519_dalek::edwards::{CompressedEdwardsY, EdwardsPoint};
 use curve25519_dalek::scalar::Scalar;
 use hex::encode as hex_encode;
+use sealed::sealed;
 use thiserror::Error;
 
 use std::ops::Range;
@@ -714,7 +715,8 @@ impl Decodable for ExtraField {
     }
 }
 
-impl Encodable for ExtraField {
+#[sealed]
+impl crate::consensus::encode::Encodable for ExtraField {
     fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
         let mut buffer = Vec::new();
         for field in self.0.iter() {
@@ -764,7 +766,8 @@ impl Decodable for SubField {
     }
 }
 
-impl Encodable for SubField {
+#[sealed]
+impl crate::consensus::encode::Encodable for SubField {
     fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
         let mut len = 0;
         match *self {
@@ -818,7 +821,8 @@ impl Decodable for TxIn {
     }
 }
 
-impl Encodable for TxIn {
+#[sealed]
+impl crate::consensus::encode::Encodable for TxIn {
     fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
         match self {
             TxIn::Gen { height } => {
@@ -851,7 +855,8 @@ impl Decodable for TxOutTarget {
     }
 }
 
-impl Encodable for TxOutTarget {
+#[sealed]
+impl crate::consensus::encode::Encodable for TxOutTarget {
     fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
         match self {
             TxOutTarget::ToKey { key } => {
@@ -942,7 +947,8 @@ impl Decodable for Transaction {
     }
 }
 
-impl Encodable for Transaction {
+#[sealed]
+impl crate::consensus::encode::Encodable for Transaction {
     fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
         let mut len = self.prefix.consensus_encode(s)?;
         match *self.prefix.version {

--- a/src/cryptonote/hash.rs
+++ b/src/cryptonote/hash.rs
@@ -23,11 +23,12 @@
 //!
 
 use curve25519_dalek::scalar::Scalar;
+use sealed::sealed;
 use tiny_keccak::{Hasher, Keccak};
 
 use std::io;
 
-use crate::consensus::encode::{self, Decodable, Encodable};
+use crate::consensus::encode::{self, Decodable};
 use crate::util::key::PrivateKey;
 #[cfg(feature = "serde_support")]
 use serde::{Deserialize, Serialize};
@@ -75,7 +76,8 @@ impl Decodable for Hash {
     }
 }
 
-impl Encodable for Hash {
+#[sealed]
+impl crate::consensus::encode::Encodable for Hash {
     fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
         self.0.consensus_encode(s)
     }
@@ -107,7 +109,8 @@ impl Decodable for Hash8 {
     }
 }
 
-impl Encodable for Hash8 {
+#[sealed]
+impl crate::consensus::encode::Encodable for Hash8 {
     fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
         self.0.consensus_encode(s)
     }

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -19,6 +19,7 @@
 
 macro_rules! impl_consensus_encoding {
     ( $thing:ident, $($field:ident),+ ) => (
+        #[sealed::sealed]
         impl $crate::consensus::encode::Encodable for $thing {
             #[inline]
             fn consensus_encode<S: ::std::io::Write>(

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -71,9 +71,10 @@ use curve25519_dalek::scalar::Scalar;
 
 use hex_literal::hex;
 
-use crate::consensus::encode::{self, Decodable, Encodable};
+use crate::consensus::encode::{self, Decodable};
 use crate::cryptonote::hash;
 
+use sealed::sealed;
 use thiserror::Error;
 
 #[cfg(feature = "serde_support")]
@@ -259,7 +260,8 @@ impl Decodable for PrivateKey {
     }
 }
 
-impl Encodable for PrivateKey {
+#[sealed]
+impl crate::consensus::encode::Encodable for PrivateKey {
     fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
         self.to_bytes().consensus_encode(s)
     }
@@ -471,7 +473,8 @@ impl Decodable for PublicKey {
     }
 }
 
-impl Encodable for PublicKey {
+#[sealed]
+impl crate::consensus::encode::Encodable for PublicKey {
     fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
         self.to_bytes().consensus_encode(s)
     }

--- a/src/util/ringct.rs
+++ b/src/util/ringct.rs
@@ -36,6 +36,7 @@ use serde_big_array_unchecked_docs::*;
 use curve25519_dalek::constants::ED25519_BASEPOINT_POINT;
 use curve25519_dalek::edwards::EdwardsPoint;
 use curve25519_dalek::scalar::Scalar;
+use sealed::sealed;
 use thiserror::Error;
 
 use std::convert::TryInto;
@@ -288,7 +289,8 @@ impl EcdhInfo {
     }
 }
 
-impl Encodable for EcdhInfo {
+#[sealed]
+impl crate::consensus::encode::Encodable for EcdhInfo {
     fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
         let mut len = 0;
         match self {
@@ -330,7 +332,8 @@ pub struct MgSig {
     pub cc: Key,
 }
 
-impl Encodable for MgSig {
+#[sealed]
+impl crate::consensus::encode::Encodable for MgSig {
     fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
         let mut len = 0;
         for ss in self.ss.iter() {
@@ -355,7 +358,8 @@ pub struct Clsag {
     pub D: Key,
 }
 
-impl Encodable for Clsag {
+#[sealed]
+impl crate::consensus::encode::Encodable for Clsag {
     fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
         let mut len = 0;
         // Encode the vector without prefix lenght
@@ -493,7 +497,8 @@ impl RctSigBase {
     }
 }
 
-impl Encodable for RctSigBase {
+#[sealed]
+impl crate::consensus::encode::Encodable for RctSigBase {
     fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
         let mut len = 0;
         len += self.rct_type.consensus_encode(s)?;
@@ -580,7 +585,8 @@ impl Decodable for RctType {
     }
 }
 
-impl Encodable for RctType {
+#[sealed]
+impl crate::consensus::encode::Encodable for RctType {
     fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
         match self {
             RctType::Null => 0u8.consensus_encode(s),


### PR DESCRIPTION
@sdbondi @thomaseizinger 

As discussed in #48, this fix `Encodable` for `TxIn`, removing the failures caused by the unused variants for scripts.

The deserialization is allowed to fail, so I kept this line in `Decodable` for `TxIn`, but we can also remove it if it makes more sense, feel free to push on top of this.
```rust
0x0 | 0x1 => Err(Error::ScriptNotSupported.into()),
...
_ => Err(encode::Error::ParseFailed("Invalid input type")),
```