### PR TITLE
Modify Hash public API

### DIFF
--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -470,7 +470,7 @@ impl TransactionPrefix {
 // To get transaction prefix hash
 impl hash::Hashable for TransactionPrefix {
     fn hash(&self) -> hash::Hash {
-        hash::Hash::hash(&serialize(self))
+        hash::Hash::new(&serialize(self))
     }
 }
 
@@ -657,19 +657,19 @@ pub enum SignatureHashError {
 impl hash::Hashable for Transaction {
     fn hash(&self) -> hash::Hash {
         match *self.prefix.version {
-            1 => hash::Hash::hash(&serialize(self)),
+            1 => hash::Hash::new(&serialize(self)),
             _ => {
                 let mut hashes: Vec<hash::Hash> = vec![self.prefix.hash()];
                 if let Some(sig_base) = &self.rct_signatures.sig {
                     hashes.push(sig_base.hash());
                     if sig_base.rct_type == RctType::Null {
-                        hashes.push(hash::Hash::null_hash());
+                        hashes.push(hash::Hash::null());
                     } else {
                         match &self.rct_signatures.p {
                             Some(p) => {
                                 let mut encoder = io::Cursor::new(vec![]);
                                 p.consensus_encode(&mut encoder, sig_base.rct_type).unwrap();
-                                hashes.push(hash::Hash::hash(&encoder.into_inner()));
+                                hashes.push(hash::Hash::new(&encoder.into_inner()));
                             }
                             None => {
                                 let empty_hash = hash::Hash::from_slice(&[
@@ -687,7 +687,7 @@ impl hash::Hashable for Transaction {
                     .into_iter()
                     .flat_map(|h| Vec::from(&h.to_bytes()[..]))
                     .collect();
-                hash::Hash::hash(&bytes)
+                hash::Hash::new(&bytes)
             }
         }
     }

--- a/src/cryptonote/hash.rs
+++ b/src/cryptonote/hash.rs
@@ -41,13 +41,13 @@ fixed_hash::construct_fixed_hash!(
 
 impl Hash {
     /// Create a null hash with all zeros.
-    pub fn null_hash() -> Hash {
+    pub fn null() -> Hash {
         Hash([0u8; 32])
     }
 
     /// Hash a stream of bytes with the Keccak-256 hash function.
-    pub fn hash(input: &[u8]) -> Hash {
-        Hash(keccak_256(input))
+    pub fn new(input: impl AsRef<[u8]>) -> Hash {
+        Hash(keccak_256(input.as_ref()))
     }
 
     /// Return the 32-bytes hash array.
@@ -65,8 +65,8 @@ impl Hash {
     /// The hash function `H` is the same Keccak function that is used in CryptoNote. When the
     /// value of the hash function is interpreted as a scalar, it is converted into a little-endian
     /// integer and taken modulo `l`.
-    pub fn hash_to_scalar(input: &[u8]) -> PrivateKey {
-        Self::hash(input).as_scalar()
+    pub fn hash_to_scalar(input: impl AsRef<[u8]>) -> PrivateKey {
+        Self::new(input).as_scalar()
     }
 }
 

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -482,7 +482,7 @@ impl crate::consensus::encode::Encodable for PublicKey {
 
 impl hash::Hashable for PublicKey {
     fn hash(&self) -> hash::Hash {
-        hash::Hash::hash(self.as_bytes())
+        hash::Hash::new(self.as_bytes())
     }
 }
 

--- a/src/util/ringct.rs
+++ b/src/util/ringct.rs
@@ -176,8 +176,8 @@ impl EcdhInfo {
         let (amount, blinding_factor) = match self {
             // ecdhDecode in rctOps.cpp else
             EcdhInfo::Standard { mask, amount } => {
-                let shared_sec1 = hash::Hash::hash(shared_key.as_bytes()).to_bytes();
-                let shared_sec2 = hash::Hash::hash(&shared_sec1).to_bytes();
+                let shared_sec1 = hash::Hash::new(shared_key.as_bytes()).to_bytes();
+                let shared_sec2 = hash::Hash::new(&shared_sec1).to_bytes();
                 let mask_scalar = Scalar::from_bytes_mod_order(mask.key)
                     - Scalar::from_bytes_mod_order(shared_sec1);
 
@@ -233,7 +233,7 @@ fn xor_amount(amount: [u8; 8], shared_key: Scalar) -> [u8; 8] {
     amount_key.extend(shared_key.as_bytes());
 
     // Hn("amount", Hn(rKbv,t))
-    let hash_shared_key = hash::Hash::hash(&amount_key).to_fixed_bytes();
+    let hash_shared_key = hash::Hash::new(&amount_key).to_fixed_bytes();
     let hash_shared_key_significant_bytes = hash_shared_key[0..8]
         .try_into()
         .expect("hash_shared_key create above has 32 bytes");
@@ -523,7 +523,7 @@ impl crate::consensus::encode::Encodable for RctSigBase {
 
 impl hash::Hashable for RctSigBase {
     fn hash(&self) -> hash::Hash {
-        hash::Hash::hash(&serialize(self))
+        hash::Hash::new(&serialize(self))
     }
 }
 


### PR DESCRIPTION
Rename `hash` method into `new` to avoid repeating the name of the type. Change `null_hash` into `null`. Relax input type for creating hash with `AsRef<[u8]>` instead of `&[u8]`.