### PR TITLE
Prepare release 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 N/A
 
+## [0.15.0] - 2021-09-27
+### Added
+- Derive `Hash` for `PrivateKey` ([#58](https://github.com/monero-rs/monero-rs/pull/58))
+- Add MSRV badge in README ([#60](https://github.com/monero-rs/monero-rs/pull/60))
+
+### Changed
+- Modify Hash public API, fix clippy ([#59](https://github.com/monero-rs/monero-rs/pull/59))
+
 ## [0.14.0] - 2021-08-17
 ### Added
 - Function for computing the signature hash of a transaction ([#41](https://github.com/monero-rs/monero-rs/pull/41))
@@ -141,7 +149,8 @@ N/A
 - Address and subaddress creation, de/serialization and validation
 - Private keys and one-time keys creation, de/serialization and validation
 
-[Unreleased]: https://github.com/monero-rs/monero-rs/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/monero-rs/monero-rs/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/monero-rs/monero-rs/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/monero-rs/monero-rs/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/monero-rs/monero-rs/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/monero-rs/monero-rs/compare/v0.11.2...v0.12.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "monero"
 description = "Rust Monero Library."
 keywords = ["monero"]
-version = "0.14.0"
-authors = ["h4sh3d <h4sh3d@protonmail.com>"]
+version = "0.15.0"
+authors = ["Monero Rust Contributors", "h4sh3d <h4sh3d@protonmail.com>"]
 license = "MIT"
 homepage = "https://github.com/monero-rs/monero-rs"
 repository = "https://github.com/monero-rs/monero-rs"


### PR DESCRIPTION
Waiting on review for #59 and #60.

Prepare release of `0.15.0`, version is bumped because #59 breaks the current API.