### PR TITLE
Release automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,8 @@ env:
 jobs:
 
   static_analysis:
-
+    name: Static Analysis
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
 
@@ -25,7 +24,7 @@ jobs:
       run: cargo clippy --workspace --all-targets -- -D warnings
 
   build:
-
+    name: Build
     strategy:
       matrix:
         rust: [
@@ -33,9 +32,7 @@ jobs:
           stable,
           nightly
         ]
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
 
@@ -61,16 +58,14 @@ jobs:
       run: cargo build --verbose --all-features
 
   test:
-
+    name: Test
     strategy:
       matrix:
         rust: [
           stable,
           nightly
         ]
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,18 @@ jobs:
     - name: Run Clippy
       run: cargo clippy --workspace --all-targets -- -D warnings
 
+  mdtomlfmt:
+    name: Generic format (md,toml)
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Run dprint
+      run: |
+        curl -fsSL https://dprint.dev/install.sh | sh
+        /home/runner/.dprint/bin/dprint check
+
   build:
     name: Build
     strategy:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,20 @@
+name: Create and publish release
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  create_release:
+    name: Create from merged release branch
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
+    uses: monero-rs/workflows/.github/workflows/create-release.yml@v1.1.0
+
+  release_to_crates:
+    name: Publish the new release to crates.io
+    uses: monero-rs/workflows/.github/workflows/release-to-crates-io.yml@v1.1.0
+    # Do not run before creating the release is done
+    needs: create_release
+    secrets:
+      cratesio_token: ${{ secrets.H4SH3D_CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -1,0 +1,16 @@
+name: Draft new release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The new version in major.minor.patch format.'
+        required: true
+
+jobs:
+  draft-new-release:
+    name: Draft a new release
+    uses: monero-rs/workflows/.github/workflows/draft-new-release.yml@v1.1.0
+    with:
+      version: ${{ github.event.inputs.version }}
+

--- a/.github/workflows/release-to-crates-io.yml
+++ b/.github/workflows/release-to-crates-io.yml
@@ -1,0 +1,14 @@
+name: Release to crates.io
+
+# In case a release is created manually, publish the release on crates.io
+on:
+  release:
+    types: [created]
+
+jobs:
+  release_to_crates:
+    name: Publish the new release to crates.io
+    uses: monero-rs/workflows/.github/workflows/release-to-crates-io.yml@v1.1.0
+    secrets:
+      cratesio_token: ${{ secrets.H4SH3D_CARGO_REGISTRY_TOKEN }}
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) as described in [The Cargo Book](https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field).
 
 ## [Unreleased]
-N/A
 
 ## [0.15.0] - 2021-09-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -7,141 +8,193 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.15.0] - 2021-09-27
+
 ### Added
+
 - Derive `Hash` for `PrivateKey` ([#58](https://github.com/monero-rs/monero-rs/pull/58))
 - Add MSRV badge in README ([#60](https://github.com/monero-rs/monero-rs/pull/60))
 
 ### Changed
+
 - Modify Hash public API, fix clippy ([#59](https://github.com/monero-rs/monero-rs/pull/59))
 
 ## [0.14.0] - 2021-08-17
+
 ### Added
+
 - Function for computing the signature hash of a transaction ([#41](https://github.com/monero-rs/monero-rs/pull/41))
 - Length bounds check before allocating `Vec` ([#47](https://github.com/monero-rs/monero-rs/pull/47))
 
 ### Changed
+
 - Don't use `io::Cursor` for implementing `Encodable` on `ExtraField` ([#49](https://github.com/monero-rs/monero-rs/pull/49))
 - Trait `Encodable` is now sealed and cannot be implemented outside of the library to guarentee a correct, non-failable, implementation ([#50](https://github.com/monero-rs/monero-rs/pull/50))
 
 ### Fixed
+
 - Activation of curve25519-dalek's serde feature ([#52](https://github.com/monero-rs/monero-rs/pull/52))
 - Clippy errors ([#53](https://github.com/monero-rs/monero-rs/pull/53))
 
 ### Removed
+
 - Unused `TxIn` variants ([#50](https://github.com/monero-rs/monero-rs/pull/50))
 
 ## [0.13.0] - 2021-06-02
+
 ### Added
+
 - `Amount` structure, based on rust-bitcoin implementation ([#33](https://github.com/monero-rs/monero-rs/pull/33))
 
 ### Changed
+
 - Replace `keccak-hash` with `tiny-keccak` ([#40](https://github.com/monero-rs/monero-rs/pull/40))
 - New `check_output` API ([#42](https://github.com/monero-rs/monero-rs/pull/42))
 - Switch CI from Travis to GitHub Actions
 
 ## [0.12.0] - 2021-04-29
+
 ### Added
+
 - More types under `strict_encoding` wrapper ([`2dba2da`](https://github.com/monero-rs/monero-rs/commit/2dba2daee9e8bcc90079009279c17ae743794185))
 - Add `TryFrom` impl. on keys and more `derive` on some types ([`dd9f1d9`](https://github.com/monero-rs/monero-rs/commit/dd9f1d9e52c31f56edddb111718285a786123bfa), [`06ed856`](https://github.com/monero-rs/monero-rs/commit/06ed856c1c898ec8ca0f3153a730234c98dfb8c4))
 
 ### Changed
+
 - Update `base58` dependency to `0.3.0` ([`56c7a0a`](https://github.com/monero-rs/monero-rs/commit/56c7a0a517b0331a80103f0ccc7c1659ec4a6686))
 - Change `pub use` over the library ([`0020a6e`](https://github.com/monero-rs/monero-rs/commit/0020a6eadff66c9b677d606868832cfd3944a804))
 - Improve overall documentation ([`43c4926`](https://github.com/monero-rs/monero-rs/commit/43c4926b3492fa59f6564e15f9a7014e34b80ce1))
 
 ## [0.11.2] - 2021-03-30
+
 ### Fixed
+
 - docs.rs compilation errors, add `feature(doc_cfg)` when building on https://doc.rs
 
 ## [0.11.1] - 2021-03-30
+
 ### Added
+
 - Package metadata for generated documentation on https://doc.rs to enable feature badges
 
 ## [0.11.0] - 2021-03-29
+
 ### Added
+
 - Amount recovery for `OwnedTxOut` with `ViewPair` ([#7](https://github.com/monero-rs/monero-rs/issues/7))
 - New feature `strict_encoding_support`, disabled by default, which wraps some Encodable and Decodable types
 
 ### Changed
+
 - Use `thiserror` on all `Error` types in the library
 - Update `base58-monero` to `0.2.1` and upgrade all dependencies
 - Simplify `Encodable` and `Decodable` traits based on the work done in [`rust-bitcoin/rust-bitcoin`](https://github.com/rust-bitcoin/rust-bitcoin), remove dependency `bytes`
 - Improve README and Rust documentation
 
 ## [0.10.0] - 2020-10-16
+
 ### Added
+
 - Support for transaction de/serialization with CLSAG signature ([#21](https://github.com/monero-rs/monero-rs/issues/21))
 
 ### Changed
+
 - Rename `EcdhInfo::Bulletproof2` into `EcdhInfo::Bulletproof`
 - Bump `curve25519-dalek` dependency to version `3`, with optional `serde` support
 
 ## [0.9.1] - 2020-09-10
+
 ### Added
+
 - Implement `Display` trait for principal structures ([`5d9716f`](https://github.com/monero-rs/monero-rs/commit/5d9716fbdb08e5e6d37103e7fe2b4a45e4c5322b))
 
 ## [0.9.0] - 2020-09-04
+
 ### Changed
+
 - Removed the deprecated `failure` crate in favour of `thiserror` ([#20](https://github.com/monero-rs/monero-rs/pull/20))
 
 ## [0.8.1] - 2020-07-20
+
 ### Fixed
+
 - `RctType::Null` deserialization for `RctSigBase` by [@StriderDM](https://github.com/StriderDM) and [@h4sh3d](https://github.com/h4sh3d)
 
 ## [0.8.0] - 2020-07-20 [YANKED]
+
 ### Changed
+
 - Replaced `std::error::Error` by `Failure` crate by [@sedddn](https://github.com/sedddn)
 
 ### Fixed
+
 - Block (de)serialization by ([`db80e61`](https://github.com/monero-rs/monero-rs/commit/db80e61443b430e6da48d0e24f6afd0ef74b79ae))
 
 ## [0.7.0] - 2020-03-29
+
 ### Changed
+
 - More code examples in documentation
 
 ### Fixed
+
 - `check_outputs` behaviour, use ranges for sub-addresses in all cases, reported by [@ladislavdubravsky](https://github.com/ladislavdubravsky)
 
 ### Removed
+
 - `SubKeyGenerator`, the implementation is not 100% tested and not needed for reading and parsing transactions
 
 ## [0.6.0] - 2020-03-22
+
 ### Added
+
 - Methods to recover public and private keys on `OwnedTxOut` ([`c7b5e11`](https://github.com/monero-rs/monero-rs/commit/c7b5e11a0b6ec4c6fecde8e2c4628d9b894edd5b))
 
 ### Fixed
+
 - Testnet and Stagenet magic bytes ([`aea9bc0`](https://github.com/monero-rs/monero-rs/commit/aea9bc0f5edd5981544e67b98c6f4211b7958eff))
 - One-time key computation, thanks to [@gtklocker](https://github.com/gtklocker) and [@ladislavdubravsky](https://github.com/ladislavdubravsky) ([`c7b5e11`](https://github.com/monero-rs/monero-rs/commit/c7b5e11a0b6ec4c6fecde8e2c4628d9b894edd5b))
 
 ## [0.5.0] - 2020-01-16
+
 ### Changed
+
 - Finer dependency versions
-- Update `dalek` to version `2.0` by [@SWvheerden ](https://github.com/SWvheerden)
+- Update `dalek` to version `2.0` by [@SWvheerden](https://github.com/SWvheerden)
 - Improved documentation and code examples
 
 ### Removed
+
 - `cdlyb` and `rlib` attributes ([`28db20c`](https://github.com/monero-rs/monero-rs/commit/28db20c690753e1beac7aaefec20542f042ab276))
 
 ## [0.4.0] - 2019-12-04
+
 ### Added
-- General serde support under `serde_support` feature by [@SWvheerden ](https://github.com/SWvheerden)
-- Debug and clone derives to most structs by [@SWvheerden ](https://github.com/SWvheerden)
+
+- General serde support under `serde_support` feature by [@SWvheerden](https://github.com/SWvheerden)
+- Debug and clone derives to most structs by [@SWvheerden](https://github.com/SWvheerden)
 
 ## [0.3.0] - 2019-10-02
+
 ### Changed
+
 - Update Rust to stable channel instead of nightly by [@vorot93](https://github.com/vorot93)
 
 ### Fixed
+
 - Rust format and syntax warnings by [@vorot93](https://github.com/vorot93)
 
 ## [0.2.0] - 2019-04-25
+
 ### Added
+
 - Serde support for `Address`
 - Usage of `fixed-hash` for `cryptonote::hash`
 - Code of Conduct
 
 ## [0.1.0] - 2019-03-15
+
 ### Added
+
 - Initial release of the library
 - CI pipeline
 - De/serialization of Monero blocks and transactions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "monero"
-description = "Rust Monero Library."
-keywords = ["monero"]
 version = "0.15.0"
 authors = ["Monero Rust Contributors", "h4sh3d <h4sh3d@protonmail.com>"]
-license = "MIT"
-homepage = "https://github.com/monero-rs/monero-rs"
-repository = "https://github.com/monero-rs/monero-rs"
 documentation = "https://docs.rs/monero"
-readme = "README.md"
+homepage = "https://github.com/monero-rs/monero-rs"
 include = [
-    "src/*",
-    "README.md",
-    "CHANGELOG.md",
-    "LICENSE",
+  "src/*",
+  "README.md",
+  "CHANGELOG.md",
+  "LICENSE",
 ]
+keywords = ["monero"]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/monero-rs/monero-rs"
+description = "Rust Monero Library."
 
 edition = "2018"
 
@@ -23,19 +23,19 @@ default = ["full"]
 full = ["fixed-hash/std", "fixed-hash/rand"]
 serde_support = ["serde", "serde-big-array", "curve25519-dalek/serde"]
 strict_encoding_support = ["strict_encoding"]
-experimental = [ ]
+experimental = []
 
 [dependencies]
+base58-monero = { version = "0.3", default-features = false }
+curve25519-dalek = { version = "3.0.2" }
 hex = "0.4.3"
 hex-literal = "0.3.1"
-tiny-keccak = { version = "2", features = ["keccak"] }
-base58-monero = { version = "0.3", default-features = false }
+sealed = "0.3"
 serde = { version = "1.0.124", features = ["derive"], optional = true }
 serde-big-array = { version = "0.3.2", optional = true }
-curve25519-dalek = { version = "3.0.2" }
-thiserror = "1.0.24"
 strict_encoding = { version = "1.2", optional = true }
-sealed = "0.3"
+thiserror = "1.0.24"
+tiny-keccak = { version = "2", features = ["keccak"] }
 
 [dependencies.fixed-hash]
 version = "0.7.0"

--- a/README.md
+++ b/README.md
@@ -39,22 +39,18 @@ The `strict_encoding_support` feature enables `StrictEncode` and `StrictDecode` 
 
 `strict_encoding` is a wrapper that allows multiple consensus encoding to work under the same interface, i.e. `StrictEncode` and `StrictDecode`.
 
-Contributing
-===
+## Contributing
 
 Contributions are generally welcome. If you intend to make larger changes please discuss them in an issue before PRing them to avoid duplicate work and architectural mismatches.
 
-Release Notes
-===
+## Releases and Changelog
 
-See [CHANGELOG.md](CHANGELOG.md).
+See [CHANGELOG.md](CHANGELOG.md) and [RELEASING.md](RELEASING.md).
 
-About
-===
+## About
 
-This started as a research project sponsored by TrueLevel SA, it is now developed and maintained by h4sh3d and member's of the community and NOT by the Monero Core Team.
+This started as a research project sponsored by TrueLevel SA, it is now developed and maintained by the Monero Rust Contributors and NOT by the Monero Core Team.
 
-Licensing
-===
+## Licensing
 
 The code in this project is licensed under the [MIT License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -5,19 +5,18 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 ![MSRV](https://img.shields.io/badge/MSRV-1.51.0-blue)
 
-Rust Monero Library
-===
+# Rust Monero Library
 
 Library with support for de/serialization on block data structures and key/address generation and scanning related to Monero cryptocurrency.
 
 Supports (or should support)
 
- * De/serialization of Monero blocks and transactions (consensus encoding)
- * Address and subaddress creation, de/serialization and validation
- * Private keys and one-time keys creation, de/serialization and validation
- * Transaction owned output detection and amount recovery with view keypair
- * Serde support on most structures with feature `serde_support`
- * Strict encoding support on most structures with feature `strict_encoding_support`
+- De/serialization of Monero blocks and transactions (consensus encoding)
+- Address and subaddress creation, de/serialization and validation
+- Private keys and one-time keys creation, de/serialization and validation
+- Transaction owned output detection and amount recovery with view keypair
+- Serde support on most structures with feature `serde_support`
+- Strict encoding support on most structures with feature `strict_encoding_support`
 
 ## Documentation
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,11 @@
+# Releasing
+
+Releases of this crate are fairly automated.
+
+To create a new release:
+
+1. Make sure `CHANGELOG.md` is up-to-date and contain all modifications under the `[Unreleased]` section.
+2. Trigger [this](https://github.com/monero-rs/monero-rs/actions/workflows/draft-new-release.yml) workflow with the desired version number.
+3. Merge the resulting PR (watch your notifications).
+
+The `[Unreleased]` section of `CHANGELOG.md` must contain all the changes that will be documented for the release.

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,13 @@
+{
+  "incremental": true,
+  "markdown": {
+  },
+  "toml": {
+  },
+  "includes": ["**/*.{md,toml}"],
+  "excludes": ["target"],
+  "plugins": [
+    "https://plugins.dprint.dev/markdown-0.11.2.wasm",
+    "https://plugins.dprint.dev/toml-0.5.3.wasm"
+  ]
+}


### PR DESCRIPTION
Add workflows to automate release management, workflows are based on `monero-rs/workflows`.

Added `dprint` in CI and ran `dprint fmt` on the code base.