### PR TITLE
chore: update base58 to version 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update `base58-monero` requirement from 0.3 to 1 ([#91](https://github.com/monero-rs/monero-rs/pull/91))
 - Update `serde-big-array` requirement from 0.3.2 to 0.4.1 ([#77](https://github.com/monero-rs/monero-rs/pull/77))
 - Update `serde_json` requirement from <1.0.45 to 1 ([#84](https://github.com/monero-rs/monero-rs/pull/84))
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde_support = ["serde", "serde-big-array", "curve25519-dalek/serde"]
 experimental = []
 
 [dependencies]
-base58-monero = { version = "0.3", default-features = false }
+base58-monero = { version = "1", default-features = false }
 curve25519-dalek = { version = "3.0.2" }
 hex = "0.4.3"
 hex-literal = "0.3.1"


### PR DESCRIPTION
Bump `base58-monero` requirement to `"1"`.