### PR TITLE
chore: add codecov config

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  precision: 1
+  round: down
+  range: "50...95"


### PR DESCRIPTION
Same config as base58-monero repo.