### PR TITLE
fix: check outputs of miner transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- make `Key64` an array of 64 32 byte keys by [@Boog900](https://github.com/Boog900) ([#86](https://github.com/monero-rs/monero-rs/pull/86))
+- Check outputs of miner transaction ([#96](https://github.com/monero-rs/monero-rs/pull/96))
+- Make `Key64` an array of 64 32 byte keys by [@Boog900](https://github.com/Boog900) ([#86](https://github.com/monero-rs/monero-rs/pull/86))
 
 ## [0.16.0] - 2021-11-15
 

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -95,7 +95,7 @@ pub enum TxIn {
 
 /// Type of output formats, only [`TxOutTarget::ToKey`] is used, other formats are legacy to the
 /// original cryptonote implementation.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "serde_crate"))]
 pub enum TxOutTarget {
@@ -138,7 +138,7 @@ impl TxOutTarget {
 }
 
 /// A transaction output, can be consumed by a [`TxIn`] input of the matching format.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "serde_crate"))]
 pub struct TxOut {
@@ -269,7 +269,7 @@ impl<'a> OwnedTxOut<'a> {
 /// public key.
 ///
 /// Extra field is composed of typed sub fields of variable or fixed length.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "serde_crate"))]
 pub struct ExtraField(pub Vec<SubField>);
@@ -353,7 +353,7 @@ impl fmt::Display for SubField {
 ///
 /// As transaction prefix implements [`hash::Hashable`] it is possible to generate the transaction
 /// prefix hash with `tx_prefix.hash()`.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(crate = "serde_crate"))]
 pub struct TransactionPrefix {

--- a/tests/data/block.json
+++ b/tests/data/block.json
@@ -1,0 +1,37 @@
+{
+  "id": "0",
+  "jsonrpc": "2.0",
+  "result": {
+    "blob": "0e0ec980f09506418015bb9ae982a1975da7d79277c2705727a56894ba0fb246adaabb1f4632e38475c625023d01ff0101808080f0ffff0702e928dfd0a413a4eac0b541fcc434c56da56cb34c95d8d6916146c3a4f7071ae82101b0f38ad895b9a7bc053e9be31ddd16139ad7006396ae7a29eb6365306ae6f4b70000",
+    "block_header": {
+      "block_size": 81,
+      "block_weight": 81,
+      "cumulative_difficulty": 2,
+      "cumulative_difficulty_top64": 0,
+      "depth": 8193,
+      "difficulty": 1,
+      "difficulty_top64": 0,
+      "hash": "bcf59f2c93dd22b0aa5a79f12af02afbba18e106a1ec86de9081a0f369967018",
+      "height": 1,
+      "long_term_weight": 81,
+      "major_version": 14,
+      "miner_tx_hash": "50ad877c2f126c9278dc4b043774bceb995c80bc2fa11de10a0f8379a856422e",
+      "minor_version": 14,
+      "nonce": 633763204,
+      "num_txes": 0,
+      "orphan_status": false,
+      "pow_hash": "",
+      "prev_hash": "418015bb9ae982a1975da7d79277c2705727a56894ba0fb246adaabb1f4632e3",
+      "reward": 35184338534400,
+      "timestamp": 1656488009,
+      "wide_cumulative_difficulty": "0x2",
+      "wide_difficulty": "0x1"
+    },
+    "credits": 0,
+    "json": "{\n  \"major_version\": 14, \n  \"minor_version\": 14, \n  \"timestamp\": 1656488009, \n  \"prev_id\": \"418015bb9ae982a1975da7d79277c2705727a56894ba0fb246adaabb1f4632e3\", \n  \"nonce\": 633763204, \n  \"miner_tx\": {\n    \"version\": 2, \n    \"unlock_time\": 61, \n    \"vin\": [ {\n        \"gen\": {\n          \"height\": 1\n        }\n      }\n    ], \n    \"vout\": [ {\n        \"amount\": 35184338534400, \n        \"target\": {\n          \"key\": \"e928dfd0a413a4eac0b541fcc434c56da56cb34c95d8d6916146c3a4f7071ae8\"\n        }\n      }\n    ], \n    \"extra\": [ 1, 176, 243, 138, 216, 149, 185, 167, 188, 5, 62, 155, 227, 29, 221, 22, 19, 154, 215, 0, 99, 150, 174, 122, 41, 235, 99, 101, 48, 106, 230, 244, 183\n    ], \n    \"rct_signatures\": {\n      \"type\": 0\n    }\n  }, \n  \"tx_hashes\": [ ]\n}",
+    "miner_tx_hash": "50ad877c2f126c9278dc4b043774bceb995c80bc2fa11de10a0f8379a856422e",
+    "status": "OK",
+    "top_hash": "",
+    "untrusted": false
+  }
+}

--- a/tests/recover_outputs.rs
+++ b/tests/recover_outputs.rs
@@ -13,9 +13,11 @@
 // copies or substantial portions of the Software.
 //
 
+use monero::blockdata::block::Block;
 use monero::blockdata::transaction::Transaction;
 use monero::consensus::encode::deserialize;
 use monero::util::key::{KeyPair, PrivateKey, PublicKey, ViewPair};
+use std::str::FromStr;
 
 const TRANSACTION: &str = "02000102000bb2e38c0189ea01a9bc02a533fe02a90705fd0540745f59f49374365304f8b4d5da63b444b2d74a40f8007ea44940c15cbbc80c9d106802000267f0f669ead579c1067cbffdf67c4af80b0287c549a10463122b4860fe215f490002b6a2e2f35a93d637ff7d25e20da326cee8e92005d3b18b3c425dabe8336568992c01d6c75cf8c76ac458123f2a498512eb65bb3cecba346c8fcfc516dc0c88518bb90209016f82359eb1fe71d604f0dce9470ed5fd4624bb9fce349a0e8317eabf4172f78a8b27dec6ea1a46da10ed8620fa8367c6391eaa8aabf4ebf660d9fe0eb7e9dfa08365a089ad2df7bce7ef776467898d5ca8947152923c54a1c5030e0c2f01035c555ff4285dcc44dfadd6bc37ec8b9354c045c6590446a81c7f53d8f199cace3faa7f17b3b8302a7cbb3881e8fdc23cca0275c9245fdc2a394b8d3ae73911e3541b10e7725cdeef5e0307bc218caefaafe97c102f39c8ce78f62cccf23c69baf0af55933c9d384ceaf07488f2f1ac7343a593449afd54d1065f6a1a4658845817e4b0e810afc4ca249096e463f9f368625fa37d5bbcbe87af68ce3c4d630f93a66defa4205b178f4e9fa04107bd535c7a4b2251df2dad255e470b611ffe00078c2916fc1eb2af1273e0df30dd1c74b6987b9885e7916b6ca711cbd4b7b50576e51af1439e9ed9e33eb97d8faba4e3bd46066a5026a1940b852d965c1db455d1401687ccaccc524e000b05966763564b7deb8fd64c7fb3d649897c94583dca1558893b071f5e6700dad139f3c6f973c7a43b207ee3e67dc7f7f18b52df442258200c7fe6d16685127da1df9b0d93d764c2659599bc6d300ae33bf8b7c2a504317da90ea2f0bb2af09bd531feae57cb4a0273d8add62fadfc6d43402372e5caf854e112b88417936f1a9c4045d48b5b0b7703d96801b35ff66c716cddbee1b92407aa069a162c163071710e28ccddf6fb560feea32485f2c54a477ae23fd8210427eabe4288cbe0ecbef4ed19ca049ceded424d9f839da957f56ffeb73060ea15498fcbc2d73606e85e963a667dafdb2641fb91862c07b98c1fdae8fadf514600225036dd63c22cdadb57d2125ebf30bc77f7ea0bc0dafb484bf01434954c5053b9c8a143f06972f80fa66788ea1e3425dc0104a9e3674729967b9819552ebb172418da0e4b3778ad4b3d6acd8f354ba09e54bbc8604540010e1e1e4d3066515aed457bd3399c0ce787236dbcd3923de4fb8faded10199b33c1251191612ab5526c1cf0cd55a0aeaed3f7a955ceced16dabdbeb0a2a19a9fdb5aa8c4fc8767cf70e4ad1838518bc6b9de7c420c1f57636579a14a5a8bdacd24e61a68adede8a2e07416c25409dd91ab78905bc99bab4ab4fb9e4ea628e09a271837769c4e67e580dcd5485e12e4e308cb4509686a7484a71f7dfe334499808c7122f07d45d89230b1f19ed86f675b7fec44ef5f3b178ae0af92ff114bd96baa264604fea5a762307bdce6cb483b7bc780d32ed5343fcc3aa306997f211dc075f6dfd66035c1db10bef8656fefbb45645264d401682e42fe3e05906f79d65481b87508f1a4c434e0d1dfc247d4276306f801a6b57e4e4a525177bae24e0bd88a216597d9db44f2604c29d8a5f74e7b934f55048690b5dcefd6489a81aa64c1edb49b320faab94130e603d99e455cfd828bca782176192ece95e9b967fe3dd698574cf0c0b6926970b156e1134658de657de42c4930e72b49c0d94da66c330ab188c10f0d2f578590f31bcac6fcff7e21f9ff67ae1a40d5a03b19301dcbbadc1aa9392795cf81f1401ec16d986a7f96fbb9e8e12ce04a2226e26b78117a4dfb757c6a44481ff68bb0909e7010988cd37146fb45d4cca4ba490aae323bb51a12b6864f88ea6897aa700ee9142eaf0880844083026f044a5e3dba4aae08578cb057976001beb27b5110c41fe336bf7879733739ce22fb31a1a6ac2c900d6d6c6facdbc60085e5c93d502542cfea90dbc62d4e061b7106f09f9c4f6c1b5506dd0550eb8b2bf17678b140de33a10ba676829092e6a13445d1857d06c715eea4492ff864f0b34d178a75a0f1353078f83cfee1440b0a20e64abbd0cab5c6e7083486002970a4904f8371805d1a0ee4aea8524168f0f39d2dfc55f545a98a031841a740e8422a62e123c8303021fb81afbb76d1120c0fbc4d3d97ba69f4e2fe086822ece2047c9ccea507008654c199238a5d17f009aa2dd081f7901d0688aa15311865a319ccba8de4023027235b5725353561c5f1185f6a063fb32fc65ef6e90339d406a6884d66be49d03daaf116ee4b65ef80dd3052a13157b929f98640c0bbe99c8323ce3419a136403dc3f7a95178c3966d2d7bdecf516a28eb2cf8cddb3a0463dc7a6248883f7be0a10aae1bb50728ec9b8880d6011b366a850798f6d7fe07103695dded3f371ca097c1d3596967320071d7f548938afe287cb9b8fae761fa592425623dcbf653028";
 
@@ -67,4 +69,69 @@ fn recover_output_and_amount() {
     let amount = out.amount();
     assert!(amount.is_some());
     assert_eq!(amount.unwrap(), 7000000000);
+}
+
+#[test]
+fn check_output_on_miner_tx() {
+    // Generated new wallet: 49cttiQ3JH4ewwyVotG84TdCe367rziTsbkpsguMSmuMBf2igZMcBZDMs7TecAvKmMg4pnrz5WmiiXQgGLSVGVWzSdv21dw
+    //
+    // spendkey:
+    // secret: 57cabb831c03159455ef561e7ce7daf841c5921b264f837d970115b9ef24c100
+    // public: d30282faa44fa7e2df5ec621bf030cd86dfc6f3d4ddcd2cfca4bca51ce1b743f
+    //
+    // viewkey:
+    // secret: b526321e8a138afba32063ac87d21f3deb05cb40a46410f8fe861f5ab95ac606
+    // public: b4c76e76ad3eac7cbcd60983966d8ce98f582a8b288acbb5cc841d69c6d2b3e3
+    //
+    // swiftly september faked having annoyed ourselves pedantic cunning
+    // fetches major potato peeled answers against building soprano
+    // eternal school lipstick wickets python puzzled large lava building
+    //
+    //   1  block unlocked       2022-06-29 07:33:29      35.184338534400 50ad877c2f126c9278dc4b043774bceb995c80bc2fa11de10a0f8379a856422e 0000000000000000 0.000000000000 49cttiQ3JH4ewwyVotG84TdCe367rziTsbkpsguMSmuMBf2igZMcBZDMs7TecAvKmMg4pnrz5WmiiXQgGLSVGVWzSdv21dw:35.184338534400 0 -
+    //
+    let block = hex::decode("0e0ec980f09506418015bb9ae982a1975da7d79277c2705727a56894ba0fb246adaabb1f4632e38475c625023d01ff0101808080f0ffff0702e928dfd0a413a4eac0b541fcc434c56da56cb34c95d8d6916146c3a4f7071ae82101b0f38ad895b9a7bc053e9be31ddd16139ad7006396ae7a29eb6365306ae6f4b70000").unwrap();
+    let block = deserialize::<Block>(&block).expect("Block deserialization failed");
+    println!("{:#?}", block);
+
+    let secret_view =
+        PrivateKey::from_str("b526321e8a138afba32063ac87d21f3deb05cb40a46410f8fe861f5ab95ac606")
+            .unwrap();
+
+    let secret_spend =
+        PrivateKey::from_str("57cabb831c03159455ef561e7ce7daf841c5921b264f837d970115b9ef24c100")
+            .unwrap();
+    let public_spend = PublicKey::from_private_key(&secret_spend);
+
+    let keypair = KeyPair {
+        view: secret_view,
+        spend: secret_spend,
+    };
+
+    let spend = public_spend;
+    let view_pair = ViewPair {
+        view: secret_view,
+        spend,
+    };
+
+    let owned_outputs = block
+        .miner_tx
+        .check_outputs(&view_pair, 0..1, 0..1)
+        .unwrap();
+
+    assert_eq!(owned_outputs.len(), 1);
+    let out = owned_outputs.get(0).unwrap();
+
+    let private_key = out.recover_key(&keypair);
+    assert_eq!(
+        "f984b89e6c4f18ff1d6e2bd9eb5571097dbc48d5d7b4cc51ac1a548cb9d3b809",
+        format!("{}", private_key)
+    );
+    assert_eq!(
+        "e928dfd0a413a4eac0b541fcc434c56da56cb34c95d8d6916146c3a4f7071ae8",
+        format!("{}", PublicKey::from_private_key(&private_key))
+    );
+
+    let amount = out.amount();
+    assert!(amount.is_some());
+    assert_eq!(amount.unwrap(), 35184338534400);
 }


### PR DESCRIPTION
Fix #83

On coinbase transactions the amount is in clear with a `RctType::Null`, this PR fixes the logic to handle that case. Data for `check_output_on_miner_tx` test has been generated with monerod and monero-wallet-cli in regtest mode.