### PR TITLE
feat: consensus en/decoding support unsized `R` and `W`

### DIFF
--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -731,7 +731,7 @@ impl hash::Hashable for Transaction {
 // ----------------------------------------------------------------------------------------------------------------
 
 impl Decodable for ExtraField {
-    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<ExtraField, encode::Error> {
+    fn consensus_decode<D: io::Read + ?Sized>(d: &mut D) -> Result<ExtraField, encode::Error> {
         let mut fields: Vec<SubField> = vec![];
         let bytes: Vec<u8> = Decodable::consensus_decode(d)?;
         let mut decoder = io::Cursor::new(&bytes[..]);
@@ -752,7 +752,7 @@ impl Decodable for ExtraField {
 
 #[sealed]
 impl crate::consensus::encode::Encodable for ExtraField {
-    fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
+    fn consensus_encode<S: io::Write + ?Sized>(&self, s: &mut S) -> Result<usize, io::Error> {
         let mut buffer = Vec::new();
         for field in self.0.iter() {
             field.consensus_encode(&mut buffer)?;
@@ -762,7 +762,7 @@ impl crate::consensus::encode::Encodable for ExtraField {
 }
 
 impl Decodable for SubField {
-    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<SubField, encode::Error> {
+    fn consensus_decode<D: io::Read + ?Sized>(d: &mut D) -> Result<SubField, encode::Error> {
         let tag: u8 = Decodable::consensus_decode(d)?;
 
         match tag {
@@ -803,7 +803,7 @@ impl Decodable for SubField {
 
 #[sealed]
 impl crate::consensus::encode::Encodable for SubField {
-    fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
+    fn consensus_encode<S: io::Write + ?Sized>(&self, s: &mut S) -> Result<usize, io::Error> {
         let mut len = 0;
         match *self {
             SubField::Padding(nbytes) => {
@@ -839,7 +839,7 @@ impl crate::consensus::encode::Encodable for SubField {
 }
 
 impl Decodable for TxIn {
-    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<TxIn, encode::Error> {
+    fn consensus_decode<D: io::Read + ?Sized>(d: &mut D) -> Result<TxIn, encode::Error> {
         let intype: u8 = Decodable::consensus_decode(d)?;
         match intype {
             0xff => Ok(TxIn::Gen {
@@ -858,7 +858,7 @@ impl Decodable for TxIn {
 
 #[sealed]
 impl crate::consensus::encode::Encodable for TxIn {
-    fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
+    fn consensus_encode<S: io::Write + ?Sized>(&self, s: &mut S) -> Result<usize, io::Error> {
         match self {
             TxIn::Gen { height } => {
                 let len = 0xffu8.consensus_encode(s)?;
@@ -879,7 +879,7 @@ impl crate::consensus::encode::Encodable for TxIn {
 }
 
 impl Decodable for TxOutTarget {
-    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<TxOutTarget, encode::Error> {
+    fn consensus_decode<D: io::Read + ?Sized>(d: &mut D) -> Result<TxOutTarget, encode::Error> {
         let outtype: u8 = Decodable::consensus_decode(d)?;
         match outtype {
             0x2 => Ok(TxOutTarget::ToKey {
@@ -892,7 +892,7 @@ impl Decodable for TxOutTarget {
 
 #[sealed]
 impl crate::consensus::encode::Encodable for TxOutTarget {
-    fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
+    fn consensus_encode<S: io::Write + ?Sized>(&self, s: &mut S) -> Result<usize, io::Error> {
         match self {
             TxOutTarget::ToKey { key } => {
                 let len = 0x2u8.consensus_encode(s)?;
@@ -908,7 +908,7 @@ impl crate::consensus::encode::Encodable for TxOutTarget {
 
 #[allow(non_snake_case)]
 impl Decodable for Transaction {
-    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Transaction, encode::Error> {
+    fn consensus_decode<D: io::Read + ?Sized>(d: &mut D) -> Result<Transaction, encode::Error> {
         let prefix: TransactionPrefix = Decodable::consensus_decode(d)?;
 
         let inputs = prefix.inputs.len();
@@ -984,7 +984,7 @@ impl Decodable for Transaction {
 
 #[sealed]
 impl crate::consensus::encode::Encodable for Transaction {
-    fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
+    fn consensus_encode<S: io::Write + ?Sized>(&self, s: &mut S) -> Result<usize, io::Error> {
         let mut len = self.prefix.consensus_encode(s)?;
         match *self.prefix.version {
             1 => {

--- a/src/cryptonote/hash.rs
+++ b/src/cryptonote/hash.rs
@@ -72,15 +72,15 @@ impl Hash {
 }
 
 impl Decodable for Hash {
-    fn consensus_decode<D: io::Read + ?Sized>(d: &mut D) -> Result<Hash, encode::Error> {
-        Ok(Hash(Decodable::consensus_decode(d)?))
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Hash, encode::Error> {
+        Ok(Hash(Decodable::consensus_decode(r)?))
     }
 }
 
 #[sealed]
 impl crate::consensus::encode::Encodable for Hash {
-    fn consensus_encode<S: io::Write + ?Sized>(&self, s: &mut S) -> Result<usize, io::Error> {
-        self.0.consensus_encode(s)
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.0.consensus_encode(w)
     }
 }
 
@@ -106,15 +106,15 @@ fixed_hash::construct_fixed_hash!(
 );
 
 impl Decodable for Hash8 {
-    fn consensus_decode<D: io::Read + ?Sized>(d: &mut D) -> Result<Hash8, encode::Error> {
-        Ok(Hash8(Decodable::consensus_decode(d)?))
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<Hash8, encode::Error> {
+        Ok(Hash8(Decodable::consensus_decode(r)?))
     }
 }
 
 #[sealed]
 impl crate::consensus::encode::Encodable for Hash8 {
-    fn consensus_encode<S: io::Write + ?Sized>(&self, s: &mut S) -> Result<usize, io::Error> {
-        self.0.consensus_encode(s)
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.0.consensus_encode(w)
     }
 }
 

--- a/src/cryptonote/hash.rs
+++ b/src/cryptonote/hash.rs
@@ -72,14 +72,14 @@ impl Hash {
 }
 
 impl Decodable for Hash {
-    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Hash, encode::Error> {
+    fn consensus_decode<D: io::Read + ?Sized>(d: &mut D) -> Result<Hash, encode::Error> {
         Ok(Hash(Decodable::consensus_decode(d)?))
     }
 }
 
 #[sealed]
 impl crate::consensus::encode::Encodable for Hash {
-    fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
+    fn consensus_encode<S: io::Write + ?Sized>(&self, s: &mut S) -> Result<usize, io::Error> {
         self.0.consensus_encode(s)
     }
 }
@@ -106,14 +106,14 @@ fixed_hash::construct_fixed_hash!(
 );
 
 impl Decodable for Hash8 {
-    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Hash8, encode::Error> {
+    fn consensus_decode<D: io::Read + ?Sized>(d: &mut D) -> Result<Hash8, encode::Error> {
         Ok(Hash8(Decodable::consensus_decode(d)?))
     }
 }
 
 #[sealed]
 impl crate::consensus::encode::Encodable for Hash8 {
-    fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
+    fn consensus_encode<S: io::Write + ?Sized>(&self, s: &mut S) -> Result<usize, io::Error> {
         self.0.consensus_encode(s)
     }
 }

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -22,23 +22,23 @@ macro_rules! impl_consensus_encoding {
         #[sealed::sealed]
         impl $crate::consensus::encode::Encodable for $thing {
             #[inline]
-            fn consensus_encode<S: ::std::io::Write + ?Sized>(
+            fn consensus_encode<W: ::std::io::Write + ?Sized>(
                 &self,
-                s: &mut S
+                w: &mut W
             ) -> Result<usize, ::std::io::Error> {
                 let mut len = 0;
-                $( len += self.$field.consensus_encode(s)?; )+
+                $( len += self.$field.consensus_encode(w)?; )+
                 Ok(len)
             }
         }
 
         impl $crate::consensus::encode::Decodable for $thing {
             #[inline]
-            fn consensus_decode<D: ::std::io::Read + ?Sized>(
-                d: &mut D
+            fn consensus_decode<R: ::std::io::Read + ?Sized>(
+                r: &mut R
             ) -> Result<$thing, $crate::consensus::encode::Error> {
                 Ok($thing {
-                    $( $field: crate::consensus::encode::Decodable::consensus_decode(d)?, )+
+                    $( $field: crate::consensus::encode::Decodable::consensus_decode(r)?, )+
                 })
             }
         }

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -22,7 +22,7 @@ macro_rules! impl_consensus_encoding {
         #[sealed::sealed]
         impl $crate::consensus::encode::Encodable for $thing {
             #[inline]
-            fn consensus_encode<S: ::std::io::Write>(
+            fn consensus_encode<S: ::std::io::Write + ?Sized>(
                 &self,
                 s: &mut S
             ) -> Result<usize, ::std::io::Error> {
@@ -34,7 +34,7 @@ macro_rules! impl_consensus_encoding {
 
         impl $crate::consensus::encode::Decodable for $thing {
             #[inline]
-            fn consensus_decode<D: ::std::io::Read>(
+            fn consensus_decode<D: ::std::io::Read + ?Sized>(
                 d: &mut D
             ) -> Result<$thing, $crate::consensus::encode::Error> {
                 Ok($thing {

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -308,7 +308,7 @@ mod serde_impl {
 }
 
 impl Decodable for Address {
-    fn consensus_decode<D: std::io::Read>(d: &mut D) -> Result<Address, encode::Error> {
+    fn consensus_decode<D: std::io::Read + ?Sized>(d: &mut D) -> Result<Address, encode::Error> {
         let address: Vec<u8> = Decodable::consensus_decode(d)?;
         Ok(Address::from_bytes(&address)?)
     }
@@ -316,7 +316,10 @@ impl Decodable for Address {
 
 #[sealed]
 impl crate::consensus::encode::Encodable for Address {
-    fn consensus_encode<S: std::io::Write>(&self, s: &mut S) -> Result<usize, std::io::Error> {
+    fn consensus_encode<S: std::io::Write + ?Sized>(
+        &self,
+        s: &mut S,
+    ) -> Result<usize, std::io::Error> {
         self.as_bytes().consensus_encode(s)
     }
 }

--- a/src/util/address.rs
+++ b/src/util/address.rs
@@ -308,19 +308,19 @@ mod serde_impl {
 }
 
 impl Decodable for Address {
-    fn consensus_decode<D: std::io::Read + ?Sized>(d: &mut D) -> Result<Address, encode::Error> {
-        let address: Vec<u8> = Decodable::consensus_decode(d)?;
+    fn consensus_decode<R: std::io::Read + ?Sized>(r: &mut R) -> Result<Address, encode::Error> {
+        let address: Vec<u8> = Decodable::consensus_decode(r)?;
         Ok(Address::from_bytes(&address)?)
     }
 }
 
 #[sealed]
 impl crate::consensus::encode::Encodable for Address {
-    fn consensus_encode<S: std::io::Write + ?Sized>(
+    fn consensus_encode<W: std::io::Write + ?Sized>(
         &self,
-        s: &mut S,
+        w: &mut W,
     ) -> Result<usize, std::io::Error> {
-        self.as_bytes().consensus_encode(s)
+        self.as_bytes().consensus_encode(w)
     }
 }
 

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -254,7 +254,7 @@ impl ops::Index<ops::RangeFull> for PrivateKey {
 }
 
 impl Decodable for PrivateKey {
-    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<PrivateKey, encode::Error> {
+    fn consensus_decode<D: io::Read + ?Sized>(d: &mut D) -> Result<PrivateKey, encode::Error> {
         let bytes: [u8; 32] = Decodable::consensus_decode(d)?;
         Ok(PrivateKey::from_slice(&bytes)?)
     }
@@ -262,7 +262,7 @@ impl Decodable for PrivateKey {
 
 #[sealed]
 impl crate::consensus::encode::Encodable for PrivateKey {
-    fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
+    fn consensus_encode<S: io::Write + ?Sized>(&self, s: &mut S) -> Result<usize, io::Error> {
         self.to_bytes().consensus_encode(s)
     }
 }
@@ -468,7 +468,7 @@ impl ops::Index<ops::RangeFull> for PublicKey {
 }
 
 impl Decodable for PublicKey {
-    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<PublicKey, encode::Error> {
+    fn consensus_decode<D: io::Read + ?Sized>(d: &mut D) -> Result<PublicKey, encode::Error> {
         let bytes: [u8; 32] = Decodable::consensus_decode(d)?;
         Ok(PublicKey::from_slice(&bytes)?)
     }
@@ -476,7 +476,7 @@ impl Decodable for PublicKey {
 
 #[sealed]
 impl crate::consensus::encode::Encodable for PublicKey {
-    fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
+    fn consensus_encode<S: io::Write + ?Sized>(&self, s: &mut S) -> Result<usize, io::Error> {
         self.to_bytes().consensus_encode(s)
     }
 }

--- a/src/util/key.rs
+++ b/src/util/key.rs
@@ -254,16 +254,16 @@ impl ops::Index<ops::RangeFull> for PrivateKey {
 }
 
 impl Decodable for PrivateKey {
-    fn consensus_decode<D: io::Read + ?Sized>(d: &mut D) -> Result<PrivateKey, encode::Error> {
-        let bytes: [u8; 32] = Decodable::consensus_decode(d)?;
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<PrivateKey, encode::Error> {
+        let bytes: [u8; 32] = Decodable::consensus_decode(r)?;
         Ok(PrivateKey::from_slice(&bytes)?)
     }
 }
 
 #[sealed]
 impl crate::consensus::encode::Encodable for PrivateKey {
-    fn consensus_encode<S: io::Write + ?Sized>(&self, s: &mut S) -> Result<usize, io::Error> {
-        self.to_bytes().consensus_encode(s)
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.to_bytes().consensus_encode(w)
     }
 }
 
@@ -468,16 +468,16 @@ impl ops::Index<ops::RangeFull> for PublicKey {
 }
 
 impl Decodable for PublicKey {
-    fn consensus_decode<D: io::Read + ?Sized>(d: &mut D) -> Result<PublicKey, encode::Error> {
-        let bytes: [u8; 32] = Decodable::consensus_decode(d)?;
+    fn consensus_decode<R: io::Read + ?Sized>(r: &mut R) -> Result<PublicKey, encode::Error> {
+        let bytes: [u8; 32] = Decodable::consensus_decode(r)?;
         Ok(PublicKey::from_slice(&bytes)?)
     }
 }
 
 #[sealed]
 impl crate::consensus::encode::Encodable for PublicKey {
-    fn consensus_encode<S: io::Write + ?Sized>(&self, s: &mut S) -> Result<usize, io::Error> {
-        self.to_bytes().consensus_encode(s)
+    fn consensus_encode<W: io::Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        self.to_bytes().consensus_encode(w)
     }
 }
 

--- a/src/util/ringct.rs
+++ b/src/util/ringct.rs
@@ -101,7 +101,7 @@ impl From<[Key; 64]> for Key64 {
 }
 
 impl Decodable for Key64 {
-    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<Key64, encode::Error> {
+    fn consensus_decode<D: io::Read + ?Sized>(d: &mut D) -> Result<Key64, encode::Error> {
         let mut key64 = Key64::new();
         for i in 0..64 {
             let key: Key = Decodable::consensus_decode(d)?;
@@ -113,7 +113,7 @@ impl Decodable for Key64 {
 
 #[sealed]
 impl crate::consensus::encode::Encodable for Key64 {
-    fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
+    fn consensus_encode<S: io::Write + ?Sized>(&self, s: &mut S) -> Result<usize, io::Error> {
         let mut len = 0;
         for i in 0..64 {
             len += self.keys[i].consensus_encode(s)?;
@@ -307,7 +307,7 @@ impl fmt::Display for EcdhInfo {
 
 impl EcdhInfo {
     /// Decode Diffie-Hellman info given the RingCt type.
-    fn consensus_decode<D: io::Read>(
+    fn consensus_decode<D: io::Read + ?Sized>(
         d: &mut D,
         rct_type: RctType,
     ) -> Result<EcdhInfo, encode::Error> {
@@ -327,7 +327,7 @@ impl EcdhInfo {
 
 #[sealed]
 impl crate::consensus::encode::Encodable for EcdhInfo {
-    fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
+    fn consensus_encode<S: io::Write + ?Sized>(&self, s: &mut S) -> Result<usize, io::Error> {
         let mut len = 0;
         match self {
             EcdhInfo::Standard { mask, amount } => {
@@ -372,7 +372,7 @@ pub struct MgSig {
 
 #[sealed]
 impl crate::consensus::encode::Encodable for MgSig {
-    fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
+    fn consensus_encode<S: io::Write + ?Sized>(&self, s: &mut S) -> Result<usize, io::Error> {
         let mut len = 0;
         for ss in self.ss.iter() {
             len += encode_sized_vec!(ss, s);
@@ -399,7 +399,7 @@ pub struct Clsag {
 
 #[sealed]
 impl crate::consensus::encode::Encodable for Clsag {
-    fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
+    fn consensus_encode<S: io::Write + ?Sized>(&self, s: &mut S) -> Result<usize, io::Error> {
         let mut len = 0;
         // Encode the vector without prefix lenght
         len += encode_sized_vec!(self.s, s);
@@ -494,7 +494,7 @@ impl fmt::Display for RctSigBase {
 
 impl RctSigBase {
     /// Decode a RingCt base signature given the number of inputs and outputs of the transaction.
-    pub fn consensus_decode<D: io::Read>(
+    pub fn consensus_decode<D: io::Read + ?Sized>(
         d: &mut D,
         inputs: usize,
         outputs: usize,
@@ -541,7 +541,7 @@ impl RctSigBase {
 
 #[sealed]
 impl crate::consensus::encode::Encodable for RctSigBase {
-    fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
+    fn consensus_encode<S: io::Write + ?Sized>(&self, s: &mut S) -> Result<usize, io::Error> {
         let mut len = 0;
         len += self.rct_type.consensus_encode(s)?;
         match self.rct_type {
@@ -614,7 +614,7 @@ impl RctType {
 }
 
 impl Decodable for RctType {
-    fn consensus_decode<D: io::Read>(d: &mut D) -> Result<RctType, encode::Error> {
+    fn consensus_decode<D: io::Read + ?Sized>(d: &mut D) -> Result<RctType, encode::Error> {
         let rct_type: u8 = Decodable::consensus_decode(d)?;
         match rct_type {
             0 => Ok(RctType::Null),
@@ -630,7 +630,7 @@ impl Decodable for RctType {
 
 #[sealed]
 impl crate::consensus::encode::Encodable for RctType {
-    fn consensus_encode<S: io::Write>(&self, s: &mut S) -> Result<usize, io::Error> {
+    fn consensus_encode<S: io::Write + ?Sized>(&self, s: &mut S) -> Result<usize, io::Error> {
         match self {
             RctType::Null => 0u8.consensus_encode(s),
             RctType::Full => 1u8.consensus_encode(s),
@@ -665,7 +665,7 @@ impl RctSigPrunable {
     /// Decode a prunable RingCt signature given the number of inputs and outputs in the
     /// transaction, the RingCt type and the number of mixins.
     #[allow(non_snake_case)]
-    pub fn consensus_decode<D: io::Read>(
+    pub fn consensus_decode<D: io::Read + ?Sized>(
         d: &mut D,
         rct_type: RctType,
         inputs: usize,
@@ -749,7 +749,7 @@ impl RctSigPrunable {
     }
 
     /// Encode the prunable RingCt signature part given the RingCt type of the transaction.
-    pub fn consensus_encode<S: io::Write>(
+    pub fn consensus_encode<S: io::Write + ?Sized>(
         &self,
         s: &mut S,
         rct_type: RctType,


### PR DESCRIPTION
Needs #103 for CI to pass

While doing `strict_encoding` integration of Monero I made some small changes on the `consensus` module.