### PR TITLE
chore: update changelog for 0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add serde support for `Index` ([#104](https://github.com/monero-rs/monero-rs/pull/104))
 
+### Changed
+
+- Relaxe generics requirement to `?Sized` in consensus encode/decode reader and writer ([#101](https://github.com/monero-rs/monero-rs/pull/101))
+
 ## [0.17.0] - 2022-06-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Relaxe generics requirement to `?Sized` in consensus encode/decode reader and writer ([#101](https://github.com/monero-rs/monero-rs/pull/101))
+- Relax generics requirement to `?Sized` in consensus encode/decode reader and writer ([#101](https://github.com/monero-rs/monero-rs/pull/101))
 
 ## [0.17.0] - 2022-06-29
 


### PR DESCRIPTION
I wasn't sure about #101 if it should be part of the changelog or not, but I guess event if it doesn't concern the public API directly it good to track that change too. So I open this one to update the changelog before releasing 0.17.1.