### PR TITLE
refactor: use `Amount` where it makes sense instead of u64 or VarInt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add serde `serialize` for `Amount` and `SignedAmount` slices by [@LeoNero](https://github.com/LeoNero) ([#107](https://github.com/monero-rs/monero-rs/pull/107))
 - Add serde `deserialize` for `Amount` and `SignedAmount` vectors by [@LeoNero](https://github.com/LeoNero) ([#107](https://github.com/monero-rs/monero-rs/pull/107))
+- Change `u64` and `VarInt` to `Amount` where it makes sense to by [@LeoNero](https://github.com/LeoNero) ([#113](https://github.com/monero-rs/monero-rs/pull/113))
 
 ## [0.17.1] - 2022-07-12
 

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -24,6 +24,7 @@ use crate::consensus::encode::{self, serialize, Decodable, VarInt};
 use crate::cryptonote::hash;
 use crate::cryptonote::onetime_key::{KeyRecoverer, SubKeyChecker};
 use crate::cryptonote::subaddress::Index;
+use crate::util::amount::Amount;
 use crate::util::key::{KeyPair, PrivateKey, PublicKey, ViewPair};
 use crate::util::ringct::{Opening, RctSig, RctSigBase, RctSigPrunable, RctType, Signature};
 
@@ -233,12 +234,12 @@ impl<'a> OwnedTxOut<'a> {
     /// Returns the unblinded or clear amount of this output.
     ///
     /// None if we didn't have enough information to unblind the output.
-    pub fn amount(&self) -> Option<u64> {
+    pub fn amount(&self) -> Option<Amount> {
         match self.opening {
             Some(Opening { amount, .. }) => Some(amount),
             None => match self.out.amount {
                 VarInt(0) => None,
-                VarInt(a) => Some(a),
+                VarInt(a) => Some(Amount::from_pico(a)),
             },
         }
     }

--- a/tests/recover_outputs.rs
+++ b/tests/recover_outputs.rs
@@ -68,7 +68,7 @@ fn recover_output_and_amount() {
 
     let amount = out.amount();
     assert!(amount.is_some());
-    assert_eq!(amount.unwrap(), 7000000000);
+    assert_eq!(amount.unwrap().as_pico(), 7000000000);
 }
 
 #[test]
@@ -133,5 +133,5 @@ fn check_output_on_miner_tx() {
 
     let amount = out.amount();
     assert!(amount.is_some());
-    assert_eq!(amount.unwrap(), 35184338534400);
+    assert_eq!(amount.unwrap().as_pico(), 35184338534400);
 }


### PR DESCRIPTION
Closes #98 

Those are the places where it seemed to make sense to change to `Amount`. Some other places use `VarInt`, but unsure if it makes sense to change to `Amount`.

Also, `fn parse_signed_to_piconero` in `amount.rs` returns `Result<(bool, u64), ParsingError>`, but it is an internal function used inside `Amount` and `SignedAmount` methods.

I did not find any places using `i64` where a `SignedAmount` could be used.