### PR TITLE
fix transaction scanning for txs with view tags and lots of outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Avoid prepending VarInt length of the blockhashing blob when using `Block::serialize_hashable()` [@parazyd](https://github.com/parazyd)([#194](https://github.com/monero-rs/monero-rs/pull/194))
 - Error out of bounds panics in `src/util/address.rs` for `from_bytes` and `from_slice` with fix [@hansieodendaal](https://github.com/hansieodendaal)([#185](https://github.com/monero-rs/monero-rs/pull/185))
 - Removed unused output types (and unused `pub fn get_pubkeys`), fixing panic when hashing transactions with those outputs [@hansieodendaal](https://github.com/hansieodendaal)([#186](https://github.com/monero-rs/monero-rs/pull/186))
-- Error extra data parse where `Padding(255)` could not be parsed successfully and where the length returned from parsing
+- Error on extra data parse where `Padding(255)` could not be parsed successfully and where the length returned from parsing
   `SubField::MysteriousMinerGate` was incorrect with fix [@hansieodendaal](https://github.com/hansieodendaal)([#184](https://github.com/monero-rs/monero-rs/pull/184))
 - Fixed memory overflow and subtract with overflow when deserializing [@hansieodendaal](https://github.com/hansieodendaal)([#183](https://github.com/monero-rs/monero-rs/pull/183))
+- Fixed tx scanning for txs with view tags and lots of outputs (some miner txs) [@Boog900](https://github.com/Boog900) ([#197](https://github.com/monero-rs/monero-rs/pull/197))
 
 ## [0.19.0] - 2023-09-15
 

--- a/src/blockdata/transaction.rs
+++ b/src/blockdata/transaction.rs
@@ -140,13 +140,13 @@ impl TxOutTarget {
 
     /// Derives a view tag and checks if it matches the outputs view tag,
     /// if no view tag is present the default is true.
-    pub fn check_view_tag(&self, rv: PublicKey, index: u8) -> bool {
+    pub fn check_view_tag(&self, rv: PublicKey, index: usize) -> bool {
         match self {
             TxOutTarget::ToTaggedKey { key: _, view_tag } => {
                 // https://github.com/monero-project/monero/blob/b6a029f222abada36c7bc6c65899a4ac969d7dee/src/crypto/crypto.cpp#L753
                 let salt: Vec<u8> = vec![118, 105, 101, 119, 95, 116, 97, 103];
                 let rv = rv.as_bytes().to_vec();
-                let buf = [salt, rv, Vec::from([index])].concat();
+                let buf = [salt, rv, serialize(&VarInt(index as u64))].concat();
                 *view_tag == hash::Hash::new(buf).as_bytes()[0]
             }
             _ => true,
@@ -537,7 +537,7 @@ impl TransactionPrefix {
                 let check_key = |pub_key| {
                     let key = out.target.as_one_time_key()?;
                     let keygen = KeyGenerator::from_key(checker.keys, pub_key);
-                    if !out.target.check_view_tag(keygen.rv, i as u8) {
+                    if !out.target.check_view_tag(keygen.rv, i) {
                         return None;
                     }
                     let sub_index = checker.check_with_key_generator(keygen, i, &key)?;


### PR DESCRIPTION
only miner txs are effected as normal txs must have 16 or less outs.

https://github.com/monero-project/monero/blob/ac02af92867590ca80b2779a7bbeafa99ff94dcb/src/crypto/crypto.cpp#L765