### PR TITLE
Disable codecov.io workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   codecov:
+    # Disabled because it requires a token
+    if: false
+
     runs-on: ubuntu-latest
     container:
       image: xd009642/tarpaulin:develop-nightly


### PR DESCRIPTION
This workflow requires a token:

```
Upload queued for processing failed: {"message":"Token required because branch is protected"}
```

I am not sure why. This PR disables it temporarily.