### PR TITLE
Pin quickcheck to ~1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ thiserror = "2.0.18"
 tiny-keccak = { version = "2", features = ["keccak"] }
 
 [dev-dependencies]
-quickcheck = "1"
+quickcheck = "~1.0.0"
 rand = "0.8"
 serde_json = "1"
 serde_test = "1"


### PR DESCRIPTION
This is to avoid duplicate dependencies (https://github.com/monero-rs/monero-rs/issues/227)